### PR TITLE
Add PostHog analytics, social metadata, and embed framework

### DIFF
--- a/entries/dev-tools/tensix-viz.json
+++ b/entries/dev-tools/tensix-viz.json
@@ -28,5 +28,6 @@
   ],
   "featured": true,
   "author": "tsingletaryTT",
-  "language": "JavaScript"
+  "language": "JavaScript",
+  "embed": { "type": "tensix-viz" }
 }

--- a/src/_data/embedTypes.js
+++ b/src/_data/embedTypes.js
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+
+const fs = require("fs");
+const path = require("path");
+
+function collectJsonFiles(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) results.push(...collectJsonFiles(full));
+    else if (entry.name.endsWith(".json")) results.push(full);
+  }
+  return results;
+}
+
+/** Returns the deduplicated set of embed types declared across all entries. */
+module.exports = function () {
+  const types = new Set();
+  const entriesDir = path.join(__dirname, "../../entries");
+  for (const file of collectJsonFiles(entriesDir)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(file, "utf-8"));
+      if (data.embed && typeof data.embed.type === "string") {
+        types.add(data.embed.type);
+      }
+    } catch (_) {}
+  }
+  return [...types];
+};

--- a/src/_data/embedTypes.js
+++ b/src/_data/embedTypes.js
@@ -27,7 +27,9 @@ module.exports = function () {
       if (data.embed && typeof data.embed.type === "string") {
         types.add(data.embed.type);
       }
-    } catch (_) {}
+    } catch (error) {
+      throw new Error(`Failed to read or parse entry JSON: ${file}: ${error.message}`);
+    }
   }
   return [...types];
 };

--- a/src/_data/embedTypes.js
+++ b/src/_data/embedTypes.js
@@ -4,10 +4,14 @@
 const fs = require("fs");
 const path = require("path");
 
+const ENTRIES_BASE = path.resolve(path.join(__dirname, "../../entries"));
+
 function collectJsonFiles(dir) {
   const results = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
+    const full = path.resolve(path.join(dir, entry.name));
+    // Never escape the entries base directory
+    if (!full.startsWith(ENTRIES_BASE + path.sep) && full !== ENTRIES_BASE) continue;
     if (entry.isDirectory()) results.push(...collectJsonFiles(full));
     else if (entry.name.endsWith(".json")) results.push(full);
   }
@@ -17,8 +21,7 @@ function collectJsonFiles(dir) {
 /** Returns the deduplicated set of embed types declared across all entries. */
 module.exports = function () {
   const types = new Set();
-  const entriesDir = path.join(__dirname, "../../entries");
-  for (const file of collectJsonFiles(entriesDir)) {
+  for (const file of collectJsonFiles(ENTRIES_BASE)) {
     try {
       const data = JSON.parse(fs.readFileSync(file, "utf-8"));
       if (data.embed && typeof data.embed.type === "string") {

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -4,9 +4,52 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="dark">
-  <title>tt-awesome — A hidden dimension of Tenstorrent awesomeness</title>
-  <meta name="description" content="A hidden dimension of Tenstorrent awesomeness — community projects, tools, models, and research for the Tenstorrent ecosystem.">
+  <title>tt-awesome — A curated list of Tenstorrent awesomeness</title>
+  <meta name="description" content="A curated list of community projects, tools, models, and research for the Tenstorrent AI hardware ecosystem.">
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="tt-awesome">
+  <meta property="og:title" content="tt-awesome — A curated list of Tenstorrent awesomeness">
+  <meta property="og:description" content="Community projects, tools, AI models, research papers, and tutorials for Tenstorrent hardware — curated by the community.">
+  <meta property="og:url" content="https://tenstorrent.github.io/tt-awesome/">
+  <meta property="og:image" content="https://tenstorrent.github.io/tt-awesome/assets/tt-awesome-og.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+
+  <!-- Twitter / X Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@tenstorrent">
+  <meta name="twitter:title" content="tt-awesome — A curated list of Tenstorrent awesomeness">
+  <meta name="twitter:description" content="Community projects, tools, AI models, research papers, and tutorials for Tenstorrent hardware — curated by the community.">
+  <meta name="twitter:image" content="https://tenstorrent.github.io/tt-awesome/assets/tt-awesome-og.png">
+
   <style>{% inlineFile "src/assets/style.css" %}</style>
+
+  <!-- PostHog analytics (same key as docs.tenstorrent.com sites) -->
+  <script>
+    (function (t, e) {
+      var o, n, p, r;
+      if (!e.__SV) {
+        window.posthog = e; e._i = []; e.init = function (i, s, a) {
+          function g(t, e) { var o = e.split("."); if (o.length === 2) { t = t[o[0]]; e = o[1]; } t[e] = function () { t.push([e].concat(Array.prototype.slice.call(arguments, 0))); }; }
+          p = t.createElement("script"); p.type = "text/javascript"; p.crossOrigin = "anonymous"; p.async = true;
+          p.src = s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") + "/static/array.js";
+          r = t.getElementsByTagName("script")[0]; r.parentNode.insertBefore(p, r);
+          var u = e; if (a !== undefined) { u = e[a] = []; } else { a = "posthog"; }
+          u.people = u.people || []; u.toString = function (t) { var e = "posthog"; if (a !== "posthog") { e += "." + a; } if (!t) { e += " (stub)"; } return e; };
+          u.people.toString = function () { return u.toString(1) + ".people (stub)"; };
+          var methods = ("init capture identify setPersonProperties reset get_distinct_id getGroups get_session_id alias set_config startSessionRecording stopSessionRecording opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug").split(" ");
+          for (n = 0; n < methods.length; n++) { g(u, methods[n]); } e._i.push([i, s, a]);
+        }; e.__SV = 1;
+      }
+    })(document, window.posthog || []);
+    posthog.init("phc_9LMRmHrCFvQNvDkPDjYBP5dZ6WchZ5bcM6T4Qj6tb0U", {
+      api_host: "https://us.i.posthog.com",
+      defaults: "2025-05-24",
+      person_profiles: "identified_only"
+    });
+  </script>
 </head>
 <body>
   {{ content | safe }}

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -21,6 +21,11 @@
 
   <style>{% inlineFile "src/assets/style.css" %}</style>
 
+  <!-- Embed asset stylesheets (loaded here so they're valid in <head>) -->
+  {%- if "tensix-viz" in embedTypes %}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/tsingletaryTT/tensix-viz@v2/tensix-viz.css">
+  {%- endif %}
+
   <!-- PostHog analytics (same key as docs.tenstorrent.com sites) -->
   <script>
     (function (t, e) {

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -13,16 +13,11 @@
   <meta property="og:title" content="tt-awesome — A curated list of Tenstorrent awesomeness">
   <meta property="og:description" content="Community projects, tools, AI models, research papers, and tutorials for Tenstorrent hardware — curated by the community.">
   <meta property="og:url" content="https://tenstorrent.github.io/tt-awesome/">
-  <meta property="og:image" content="https://tenstorrent.github.io/tt-awesome/assets/tt-awesome-og.png">
-  <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
-
   <!-- Twitter / X Card -->
-  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@tenstorrent">
   <meta name="twitter:title" content="tt-awesome — A curated list of Tenstorrent awesomeness">
   <meta name="twitter:description" content="Community projects, tools, AI models, research papers, and tutorials for Tenstorrent hardware — curated by the community.">
-  <meta name="twitter:image" content="https://tenstorrent.github.io/tt-awesome/assets/tt-awesome-og.png">
 
   <style>{% inlineFile "src/assets/style.css" %}</style>
 

--- a/src/_includes/embeds/tensix-viz.njk
+++ b/src/_includes/embeds/tensix-viz.njk
@@ -3,8 +3,7 @@
   Shows live BH + WH chip topology widgets with a mode switcher.
   Triggered by "embed": { "type": "tensix-viz" } in the entry JSON.
 #}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/tsingletaryTT/tensix-viz@main/tensix-viz.css">
-<script src="https://cdn.jsdelivr.net/gh/tsingletaryTT/tensix-viz@main/tensix-viz.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/tsingletaryTT/tensix-viz@v2/tensix-viz.js"></script>
 
 <div class="detail-section editorial-embed editorial-embed--tensix-viz">
   <div class="section-label">Live chip topology</div>

--- a/src/_includes/embeds/tensix-viz.njk
+++ b/src/_includes/embeds/tensix-viz.njk
@@ -1,0 +1,45 @@
+{#
+  Embed: tensix-viz
+  Shows live BH + WH chip topology widgets with a mode switcher.
+  Triggered by "embed": { "type": "tensix-viz" } in the entry JSON.
+#}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/tsingletaryTT/tensix-viz@main/tensix-viz.css">
+<script src="https://cdn.jsdelivr.net/gh/tsingletaryTT/tensix-viz@main/tensix-viz.js"></script>
+
+<div class="detail-section editorial-embed editorial-embed--tensix-viz">
+  <div class="section-label">Live chip topology</div>
+
+  <div class="embed-chip-pair">
+    <div class="embed-chip-item">
+      <div class="embed-chip-label">Blackhole · P100 / P150 / P300c · 140 Tensix cores</div>
+      <canvas data-viz="chip" data-config="blackhole" data-mode="idle" width="340" height="240"></canvas>
+    </div>
+    <div class="embed-chip-item">
+      <div class="embed-chip-label">Wormhole · N150 / N300 · 64 Tensix cores</div>
+      <canvas data-viz="chip" data-config="wormhole" data-mode="idle" width="220" height="260"></canvas>
+    </div>
+  </div>
+
+  <div class="embed-mode-bar">
+    <span class="embed-mode-label">mode</span>
+    <button class="embed-mode-btn active" data-mode="idle">idle</button>
+    <button class="embed-mode-btn" data-mode="inference">inference</button>
+    <button class="embed-mode-btn" data-mode="thinking">thinking</button>
+    <button class="embed-mode-btn" data-mode="kernel_dispatch">kernel dispatch</button>
+  </div>
+
+  <script>
+    (function () {
+      var embed = document.currentScript.parentElement;
+      var canvases = embed.querySelectorAll('canvas[data-viz="chip"]');
+      embed.querySelectorAll('.embed-mode-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var mode = this.dataset.mode;
+          embed.querySelectorAll('.embed-mode-btn').forEach(function (b) { b.classList.remove('active'); });
+          this.classList.add('active');
+          canvases.forEach(function (c) { if (c._tensixViz) c._tensixViz.activate(mode); });
+        });
+      });
+    })();
+  </script>
+</div>

--- a/src/_includes/embeds/tensix-viz.njk
+++ b/src/_includes/embeds/tensix-viz.njk
@@ -16,7 +16,7 @@
     </div>
     <div class="embed-chip-item">
       <div class="embed-chip-label">Wormhole · N150 / N300 · 64 Tensix cores</div>
-      <canvas data-viz="chip" data-config="wormhole" data-mode="idle" width="220" height="260"></canvas>
+      <canvas data-viz="chip" data-config="wormhole" data-mode="idle" width="200" height="240"></canvas>
     </div>
   </div>
 

--- a/src/_includes/entry-detail.njk
+++ b/src/_includes/entry-detail.njk
@@ -74,6 +74,10 @@
       {%- endfor %}
     </div>
     {%- endif %}
+    {%- if entry.embed %}
+    {%- set embedPath = "embeds/" + entry.embed.type + ".njk" %}
+    {%- include embedPath %}
+    {%- endif %}
   </div>
   {%- endfor %}
 </div>

--- a/src/_includes/entry-detail.njk
+++ b/src/_includes/entry-detail.njk
@@ -75,8 +75,9 @@
     </div>
     {%- endif %}
     {%- if entry.embed %}
-    {%- set embedPath = "embeds/" + entry.embed.type + ".njk" %}
-    {%- include embedPath %}
+    {%- set _embedWhitelist = { "tensix-viz": "embeds/tensix-viz.njk" } %}
+    {%- set _embedPath = _embedWhitelist[entry.embed.type] %}
+    {%- if _embedPath %}{%- include _embedPath %}{%- endif %}
     {%- endif %}
   </div>
   {%- endfor %}

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -11,13 +11,15 @@ document.addEventListener("DOMContentLoaded", () => {
   // so direct links and browser history both land in the right place.
   restoreFromUrl();
 
-  // Search — when typing while on the home view, jump into "all" mode
+  // Search — when typing while on the home view, switch to cross-category search mode.
+  // When the query is cleared in that mode, return home.
   document.getElementById("search").addEventListener("input", (e) => {
     const q = e.target.value.toLowerCase().trim();
     if (q && isHomeActive()) {
-      // Select the first category to surface results
-      const first = document.querySelector(".sidebar-item[data-category]");
-      if (first) selectCategory(first.dataset.category, first);
+      _applySearchAll();
+    } else if (!q && activeCategory === null && !isHomeActive()) {
+      _applyHome();
+      return;
     }
     applyFilters(q);
   });
@@ -86,6 +88,15 @@ function _applyHome() {
   document.getElementById("panes").classList.add("home-active");
   document.querySelectorAll(".sidebar-item").forEach((i) => i.classList.remove("active"));
   document.getElementById("home-item").classList.add("active");
+}
+
+/** Internal: show list pane with no category filter (cross-category search). No history push. */
+function _applySearchAll() {
+  activeCategory = null;
+  document.getElementById("panes").classList.remove("home-active");
+  document.querySelectorAll(".sidebar-item").forEach((i) => i.classList.remove("active"));
+  document.getElementById("list-title").textContent = "All";
+  _clearDetail();
 }
 
 /** Navigate to a category by slug — used by the home page card clicks. */

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -131,6 +131,26 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 .pkg-badge--cargo  { background: var(--bg1); color: #CE4A25; border-color: #CE4A25; }
 .pkg-badge:hover   { filter: brightness(1.2); }
 
+/* ── Editorial embeds ────────────────────────────────────────────────────── */
+.editorial-embed { margin-top: 8px; }
+
+/* tensix-viz: two chips side by side with a mode switcher */
+.embed-chip-pair  { display: flex; gap: 20px; flex-wrap: wrap; margin: 10px 0 12px; }
+.embed-chip-item  { display: flex; flex-direction: column; gap: 6px; }
+.embed-chip-label { font-size: 10px; letter-spacing: 0.8px; color: var(--muted);
+                    text-transform: uppercase; }
+.embed-chip-item canvas { border-radius: 5px; max-width: 100%; }
+
+.embed-mode-bar   { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; }
+.embed-mode-label { font-size: 9px; letter-spacing: 1.5px; text-transform: uppercase;
+                    color: var(--muted); margin-right: 4px; }
+.embed-mode-btn   { font-size: 10px; padding: 3px 9px; border-radius: 10px; border: none;
+                    cursor: pointer; background: var(--bg1); color: var(--muted);
+                    transition: background 0.15s, color 0.15s; letter-spacing: 0.2px; }
+.embed-mode-btn:hover  { color: var(--text); background: var(--bg2); }
+.embed-mode-btn.active { background: rgba(79,209,197,0.12); color: var(--teal);
+                         outline: 1px solid rgba(79,209,197,0.3); }
+
 /* ── Home / Welcome view ─────────────────────────────────────────────────── */
 .home-view { flex: 1; overflow-y: auto; padding: 36px 44px 48px; }
 


### PR DESCRIPTION
This pull request introduces a new editorial embed feature for displaying live chip topology visualizations, improves SEO and social sharing metadata, and enhances the search user experience. The main changes include support for the `tensix-viz` embed, updated meta tags for better discoverability, and refined search behavior on the home view.

**Editorial embed support:**

* Added support for entry-level embeds by checking for an `embed` property in entry JSON and including the corresponding template in `entry-detail.njk`. [[1]](diffhunk://#diff-4d15915e2ba86ebd25ded93646fbb0c917a227a8238232fb642e2e0c238ae13bL31-R32) [[2]](diffhunk://#diff-a40a1cc34b1b3c7020baa7fdaf3ac867cc2234a381bb3461d6cee676e468d882R77-R80)
* Implemented the `tensix-viz` embed template, which loads external visualization assets and provides a mode switcher for live chip topology displays.
* Added custom styles for editorial embeds and the `tensix-viz` widget to `style.css`.

**SEO and analytics improvements:**

* Updated the site title and description, and added Open Graph and Twitter Card meta tags for improved SEO and social sharing. Also integrated PostHog analytics tracking.

**Search experience enhancements:**

* Refined search input behavior: typing in the search box on the home view now triggers a cross-category search mode, and clearing the search returns the user to the home view. [[1]](diffhunk://#diff-53665b2ca0240ef1fe22bfc3e86da6aa00c5de29bcb85c7420ef29c4378f3aebL14-R22) [[2]](diffhunk://#diff-53665b2ca0240ef1fe22bfc3e86da6aa00c5de29bcb85c7420ef29c4378f3aebR93-R101)