### PR TITLE
Skip dev/nightly release tags in summarization

### DIFF
--- a/scripts/summarize_releases.py
+++ b/scripts/summarize_releases.py
@@ -208,6 +208,12 @@ def main(argv: list | None = None):
                 continue
             name = release.get("name") or tag
 
+            # Skip dev/nightly builds: matches "1.3.0.dev20260609" and "v0.73.0-dev20260610".
+            # Mirrors the filter in .eleventy.js planetItems for the recentReleases path.
+            if re.search(r"[.\-]dev[.\d]", tag, re.IGNORECASE):
+                print(f"  SKIP {repo}@{tag}: dev/nightly build")
+                continue
+
             # Fetch and quality-gate the release body before calling the LLM.
             body = fetch_release_body(repo, tag)
             if is_sparse(body):

--- a/tests/test_summarize_releases.py
+++ b/tests/test_summarize_releases.py
@@ -107,6 +107,39 @@ def test_is_sparse_false_for_substantial_body():
     assert sr.is_sparse(body) is False
 
 
+def test_main_skips_dev_build_tags(tmp_path, monkeypatch):
+    # tt-forge style: "1.3.0.dev20260609002802"; tt-metal style: "v0.73.0-dev20260610"
+    dev_tags = [
+        "1.3.0.dev20260609002802",
+        "v0.73.0-dev20260610",
+        "v0.9.5-dev.260424",
+    ]
+    releases = [
+        {"tagName": t, "name": t, "publishedAt": "2026-06-01T00:00:00Z",
+         "url": f"https://github.com/tenstorrent/tt-metal/releases/tag/{t}",
+         "prerelease": False}
+        for t in dev_tags
+    ]
+    meta = {"https://github.com/tenstorrent/tt-metal": {"releases": releases}}
+    meta_file  = tmp_path / "github_meta.json"
+    feeds_file = tmp_path / "planet_feeds.json"
+    meta_file.write_text(json.dumps(meta))
+    feeds_file.write_text(json.dumps([]))
+    entry_dir = tmp_path / "entries"
+    entry_dir.mkdir()
+
+    monkeypatch.setattr(sr, "META_IN",     meta_file)
+    monkeypatch.setattr(sr, "FEEDS_OUT",   feeds_file)
+    monkeypatch.setattr(sr, "ENTRIES_DIR", entry_dir)
+    monkeypatch.setattr(sr, "TOKEN",       "fake-token")
+
+    with patch.object(sr, "fetch_release_body") as mock_body:
+        sr.main([])
+
+    mock_body.assert_not_called()
+    assert json.loads(feeds_file.read_text()) == []
+
+
 def test_call_summarization_model_returns_summary():
     api_response = {
         "content": [{"type": "text", "text": "This release adds multi-chip support."}]


### PR DESCRIPTION
This pull request improves the handling of development and nightly build releases in the release summarization script. It introduces logic to skip dev/nightly builds based on tag patterns, ensuring that only stable releases are processed and summarized. The changes also add comprehensive testing for this new filtering behavior.

Release filtering improvements:

* Updated `main` in `scripts/summarize_releases.py` to skip releases with tags matching dev/nightly build patterns (e.g., containing `.dev` or `-dev`), mirroring the filtering logic used elsewhere in the project.

Testing enhancements:

* Added a new test `test_main_skips_dev_build_tags` in `tests/test_summarize_releases.py` to verify that releases with dev/nightly tags are skipped and not processed by the summarization logic.