### PR TITLE
Rebase onto origin/main after commit to prevent unstaged changes error

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,12 +52,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin main
-          git rebase origin/main
           git add src/_data/github_meta.json src/_data/planet_feeds.json README.md
           if git diff --cached --quiet; then
             echo "No data changes — nothing to push"
           else
             git commit -m "chore: update GitHub metadata"
+            git fetch origin main
+            git rebase origin/main
             git push origin HEAD:main
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,6 +20,8 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with: { python-version: "3.11" }
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the workflow in `.github/workflows/nightly.yml` to improve how data updates are handled before pushing changes. The main change is to ensure that the repository is only rebased onto `main` if there are actual data changes to commit.

Workflow improvement:

* Moved the `git fetch origin main` and `git rebase origin/main` commands to occur only after staging and checking for data changes, ensuring that rebasing only happens when there are updates to push.…ged-changes error)