### PR TITLE
Enhance feed content with rich HTML and LLM summaries

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -138,6 +138,15 @@ module.exports = function (eleventyConfig) {
   // `| cdataSafe | safe` in Atom templates. See buildFeedContentHtml above.
   eleventyConfig.addFilter("feedContentHtml", (item) => buildFeedContentHtml(item));
 
+  // Return the first link of a given type (e.g. "repo") from a links array, or
+  // null. Templates use this instead of `links | selectattr("type","equalto",
+  // type) | first` — selectattr is unreliable in Eleventy's Nunjucks (see the
+  // planetCount note below), so we resolve link selection in JS where it's
+  // predictable and unit-testable.
+  eleventyConfig.addFilter("firstLinkOfType", (links, type) =>
+    (links || []).find((l) => l && l.type === type) || null
+  );
+
   // Build a feed timestamp from a date that may be date-only (entry `added_at`
   // is "YYYY-MM-DD" with no time). Many entries share an `added_at`, so emitting
   // a flat "T00:00:00Z" leaves readers that sort by <updated>/date_published

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -220,6 +220,12 @@ module.exports = function (eleventyConfig) {
           linkUrl:    link.url,
           linkLabel:  link.label || (link.type.charAt(0).toUpperCase() + link.type.slice(1)),
           added_at:   entry.added_at || "1970-01-01",
+          // feedContentHtml contract fields:
+          description: entry.description || "",
+          links:      entry.links || [],
+          author:     entry.author || "",
+          author_url: entry.author_url || "",
+          tags:       entry.tags || [],
         });
         if (items.length >= limit) return items;
       }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -245,14 +245,13 @@ module.exports = function (eleventyConfig) {
 
     // 1. Release items — one per entry in recentReleases.
     for (const rel of recentReleases || []) {
-      const summary = `${rel.entryName} released ${rel.tagName}. Repository: ${rel.repoUrl}`;
+      const summary = rel.summary ||
+        `${rel.entryName} released ${rel.tagName}. Repository: ${rel.repoUrl}`;
       items.push({
         id:             rel.url,
         url:            rel.url,
         title:          `${rel.entryName} ${rel.tagName}`,
-        // content_html satisfies JSON Feed 1.1 (an item needs content_html or
-        // content_text) and renders any inline markdown; summary stays plain text.
-        content_html:   mdInline.renderInline(summary),
+        content_html:   buildFeedContentHtml(rel),
         summary:        summary,
         date_published: rel.publishedAt,
         tags:           [rel.affiliation, "release"].filter(Boolean),
@@ -287,7 +286,7 @@ module.exports = function (eleventyConfig) {
         id:             repoUrl || `https://tenstorrent.github.io/tt-awesome/#${entry.id}`,
         url:            repoUrl || (anyLink ? anyLink.url : `https://tenstorrent.github.io/tt-awesome/#${entry.id}`),
         title:          entry.name,
-        content_html:   mdInline.renderInline(entry.description || ""),
+        content_html:   buildFeedContentHtml(entry),
         summary:        entry.description || "",
         date_published: entryDate,
         tags:           [...(entry.categories || []), entry.affiliation, "entry"].filter(Boolean),
@@ -302,7 +301,7 @@ module.exports = function (eleventyConfig) {
           id:             link.url,
           url:            link.url,
           title:          `${entry.name} — ${link.label || link.type}`,
-          content_html:   mdInline.renderInline(entry.description || ""),
+          content_html:   buildFeedContentHtml(entry),
           summary:        entry.description || "",
           date_published: entryDate,
           tags:           [

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -46,28 +46,42 @@ function buildFeedContentHtml(item) {
     (l) => l && l.url && /^https?:\/\//i.test(l.url)
   );
   if (links.length) {
-    const lis = links
+    // Render links inline, separated by " · ", rather than as a <ul>/<li> list.
+    // HTML readers show a tidy one-liner, and — crucially — clients that flatten
+    // HTML to plain text (Slack's RSS app, plain-text views) still get readable
+    // output: "<li>Repo</li><li>1.3.0</li>" flattens to "Repo1.3.0", but
+    // "<a>Repo</a> · <a>1.3.0</a>" flattens to "Repo · 1.3.0". (See deep feed
+    // review 2026-06-29.)
+    const anchors = links
       .map((l) => {
         const label = l.label
           ? escapeHtml(l.label)
           : l.type
           ? escapeHtml(l.type.charAt(0).toUpperCase() + l.type.slice(1))
           : escapeHtml(l.url);
-        return `<li><a href="${escapeHtml(l.url)}">${label}</a></li>`;
+        return `<a href="${escapeHtml(l.url)}">${label}</a>`;
       })
-      .join("");
-    parts.push(`<p><strong>Links:</strong></p>\n<ul>${lis}</ul>`);
+      .join(" · ");
+    parts.push(`<p><strong>Links:</strong> ${anchors}</p>`);
   }
 
-  // 3. Attribution — author (linked when we have a profile URL), affiliation,
-  //    date added, separated by middots.
+  // 3. Attribution — author, affiliation, date added, separated by middots.
   const attr = [];
   if (item.author) {
-    attr.push(
-      item.author_url
-        ? `By <a href="${escapeHtml(item.author_url)}">@${escapeHtml(item.author)}</a>`
-        : `By @${escapeHtml(item.author)}`
-    );
+    // Only treat the author as a GitHub @handle when author_url is a github.com
+    // profile (entries.js derives that URL from the repo owner login). For
+    // papers/talks/blogs the `author` field is a display name or author list
+    // ("Jenny Lynn Almerol, …"), so an "@" prefix would be misleading — render
+    // it as a plain name instead. (See deep feed review 2026-06-29.)
+    const isGitHubHandle =
+      item.author_url && /^https?:\/\/github\.com\//i.test(item.author_url);
+    if (isGitHubHandle) {
+      attr.push(`By <a href="${escapeHtml(item.author_url)}">@${escapeHtml(item.author)}</a>`);
+    } else if (item.author_url) {
+      attr.push(`By <a href="${escapeHtml(item.author_url)}">${escapeHtml(item.author)}</a>`);
+    } else {
+      attr.push(`By ${escapeHtml(item.author)}`);
+    }
   }
   if (item.affiliation) attr.push(escapeHtml(item.affiliation));
   if (item.added_at) attr.push(`added ${escapeHtml(item.added_at)}`);
@@ -80,6 +94,20 @@ function buildFeedContentHtml(item) {
   }
 
   return parts.join("\n");
+}
+
+// Build a feed timestamp from a date that may be date-only. See the feedDateTime
+// filter registration below for the full rationale. Shared as a module-scope
+// function so both the filter and jsonFeedItems produce identical timestamps.
+function feedDateTime(dateStr, index = 0) {
+  if (!dateStr) return "1970-01-01T00:00:00Z";
+  if (/T\d{2}:\d{2}/.test(dateStr)) return dateStr; // already a full timestamp
+  const i = Math.max(0, Math.min(86399, Number(index) || 0)); // clamp to 1 day
+  const secs = 86399 - i; // earlier in feed (newer) → later time that day
+  const hh = String(Math.floor(secs / 3600)).padStart(2, "0");
+  const mm = String(Math.floor((secs % 3600) / 60)).padStart(2, "0");
+  const ss = String(secs % 60).padStart(2, "0");
+  return `${dateStr}T${hh}:${mm}:${ss}Z`;
 }
 
 module.exports = function (eleventyConfig) {
@@ -104,6 +132,26 @@ module.exports = function (eleventyConfig) {
   // Render the full rich HTML content block for a feed item. Pair with
   // `| cdataSafe | safe` in Atom templates. See buildFeedContentHtml above.
   eleventyConfig.addFilter("feedContentHtml", (item) => buildFeedContentHtml(item));
+
+  // Build a feed timestamp from a date that may be date-only (entry `added_at`
+  // is "YYYY-MM-DD" with no time). Many entries share an `added_at`, so emitting
+  // a flat "T00:00:00Z" leaves readers that sort by <updated>/date_published
+  // unable to order same-day items. We synthesize a deterministic *descending*
+  // time-of-day from the item's position in the (newest-first) feed so that
+  // date-sorting in a reader reproduces our curated order. This is an ordering
+  // key, NOT a real timestamp — `added_at` carries no real time-of-day.
+  // Strings that already include a time (release `publishedAt`) pass through.
+  eleventyConfig.addFilter("feedDateTime", (dateStr, index = 0) =>
+    feedDateTime(dateStr, index)
+  );
+
+  // Collapse all runs of whitespace (including newlines) to single spaces.
+  // Used on the release feed <summary> so a multi-paragraph summary can never
+  // render as a run-on — the summary must be a single clean line, while the
+  // full text still appears (with paragraphs) in <content>.
+  eleventyConfig.addFilter("singleLine", (str) =>
+    (str || "").replace(/\s+/g, " ").trim()
+  );
 
   // Make a string safe to embed inside an XML CDATA section. A literal "]]>"
   // would close the section early and break the feed (or allow injection), so
@@ -282,10 +330,10 @@ module.exports = function (eleventyConfig) {
       const anyLink  = (entry.links || []).find((l) => l.url);
       const repoUrl  = repoLink ? repoLink.url : null;
 
-      // Date helper — ensure full ISO 8601 timestamp.
-      const entryDate = entry.added_at
-        ? `${entry.added_at}T00:00:00Z`
-        : "1970-01-01T00:00:00Z";
+      // Full ISO 8601 timestamp. added_at is date-only, so synthesize a
+      // deterministic descending time-of-day from the feed position (i) to give
+      // same-day items a stable order in date-sorting readers. See feedDateTime.
+      const entryDate = feedDateTime(entry.added_at, i);
 
       // 2a. One item for the entry itself.
       items.push({
@@ -307,7 +355,11 @@ module.exports = function (eleventyConfig) {
           id:             link.url,
           url:            link.url,
           title:          `${entry.name} — ${link.label || link.type}`,
-          content_html:   buildFeedContentHtml(entry),
+          // This item represents one specific link, so its content lists only
+          // that link — not the entry's whole link set (which the entry item
+          // above already carries). Avoids byte-identical duplicate content
+          // across the two items in the combined feed. (Deep feed review.)
+          content_html:   buildFeedContentHtml({ ...entry, links: [link] }),
           summary:        entry.description || "",
           date_published: entryDate,
           tags:           [

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -18,6 +18,65 @@ const mdInline = new MarkdownIt({ html: false, linkify: false });
 // tracking pixels / unexpected network requests. We keep links/code/emphasis only.
 mdInline.disable("image");
 
+// Block-level markdown renderer for full feed <content> blocks. Same safety
+// posture as mdInline (no raw HTML, no auto-fetching images), but keeps block
+// wrappers so multi-paragraph release summaries render as real <p> tags.
+const mdBlock = new MarkdownIt({ html: false, linkify: false });
+mdBlock.disable("image");
+
+// Shared HTML escaper for text we interpolate directly into the content block.
+const escapeHtml = mdBlock.utils.escapeHtml;
+
+// Build the rich HTML <content> block shared by every feed (Atom <content
+// type="html"> and JSON Feed content_html). Sections whose data is absent are
+// omitted entirely. Accepts a single normalized object — see plan Task 1.
+function buildFeedContentHtml(item) {
+  if (!item) return "";
+  const parts = [];
+
+  // 1. Description / summary — block markdown (paragraphs preserved).
+  if (item.description) parts.push(mdBlock.render(item.description));
+
+  // 2. Links — every typed link as a labeled anchor. Label falls back to a
+  //    title-cased link type (e.g. "article" → "Article").
+  const links = (item.links || []).filter((l) => l && l.url);
+  if (links.length) {
+    const lis = links
+      .map((l) => {
+        const label = l.label
+          ? escapeHtml(l.label)
+          : l.type
+          ? escapeHtml(l.type.charAt(0).toUpperCase() + l.type.slice(1))
+          : escapeHtml(l.url);
+        return `<li><a href="${escapeHtml(l.url)}">${label}</a></li>`;
+      })
+      .join("");
+    parts.push(`<p><strong>Links:</strong></p>\n<ul>${lis}</ul>`);
+  }
+
+  // 3. Attribution — author (linked when we have a profile URL), affiliation,
+  //    date added, separated by middots.
+  const attr = [];
+  if (item.author) {
+    attr.push(
+      item.author_url
+        ? `By <a href="${escapeHtml(item.author_url)}">@${escapeHtml(item.author)}</a>`
+        : `By @${escapeHtml(item.author)}`
+    );
+  }
+  if (item.affiliation) attr.push(escapeHtml(item.affiliation));
+  if (item.added_at) attr.push(`added ${escapeHtml(item.added_at)}`);
+  if (attr.length) parts.push(`<p>${attr.join(" · ")}</p>`);
+
+  // 4. Tags + categories — comma-separated, emphasized.
+  const tagBits = [...(item.tags || []), ...(item.categories || [])];
+  if (tagBits.length) {
+    parts.push(`<p><em>${tagBits.map(escapeHtml).join(", ")}</em></p>`);
+  }
+
+  return parts.join("\n");
+}
+
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("src/assets");
   eleventyConfig.addPassthroughCopy({ ".nojekyll": ".nojekyll" });
@@ -36,6 +95,10 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter("markdownInline", (str) =>
     str ? mdInline.renderInline(str) : ""
   );
+
+  // Render the full rich HTML content block for a feed item. Pair with
+  // `| cdataSafe | safe` in Atom templates. See buildFeedContentHtml above.
+  eleventyConfig.addFilter("feedContentHtml", (item) => buildFeedContentHtml(item));
 
   // Make a string safe to embed inside an XML CDATA section. A literal "]]>"
   // would close the section early and break the feed (or allow injection), so

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -39,7 +39,12 @@ function buildFeedContentHtml(item) {
 
   // 2. Links — every typed link as a labeled anchor. Label falls back to a
   //    title-cased link type (e.g. "article" → "Article").
-  const links = (item.links || []).filter((l) => l && l.url);
+  // Defense-in-depth: only render http(s) links. Entry/release URLs are
+  // https-validated upstream (entries.js isSafeHttpsUrl), but this builder is
+  // general — drop javascript:/data:/etc. so a bad URL can't become a live href.
+  const links = (item.links || []).filter(
+    (l) => l && l.url && /^https?:\/\//i.test(l.url)
+  );
   if (links.length) {
     const lis = links
       .map((l) => {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -73,11 +73,16 @@ function buildFeedContentHtml(item) {
     // papers/talks/blogs the `author` field is a display name or author list
     // ("Jenny Lynn Almerol, …"), so an "@" prefix would be misleading — render
     // it as a plain name instead. (See deep feed review 2026-06-29.)
+    // Same defense-in-depth as the link list: only turn author_url into a live
+    // <a href> when it's an http(s) URL, so an unvalidated javascript:/data:
+    // author_url can't become an XSS vector; otherwise render the name plainly.
+    const httpAuthorUrl =
+      item.author_url && /^https?:\/\//i.test(item.author_url);
     const isGitHubHandle =
-      item.author_url && /^https?:\/\/github\.com\//i.test(item.author_url);
+      httpAuthorUrl && /^https?:\/\/github\.com\//i.test(item.author_url);
     if (isGitHubHandle) {
       attr.push(`By <a href="${escapeHtml(item.author_url)}">@${escapeHtml(item.author)}</a>`);
-    } else if (item.author_url) {
+    } else if (httpAuthorUrl) {
       attr.push(`By <a href="${escapeHtml(item.author_url)}">${escapeHtml(item.author)}</a>`);
     } else {
       attr.push(`By ${escapeHtml(item.author)}`);

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ A curated directory of projects, tools, models, and research for Tenstorrent har
   by [@jaebaek](https://github.com/jaebaek) — Simple C++ kernel experiments on a GraySkull e75 chip. Hands-on examples for learning the TT-Metal programming model at the metal level.
   [📦 repo](https://github.com/jaebaek/tenstorrent-tiny-examples)
 
+- **[tt-splat — matrix-native 3D Gaussian Splatting on Blackhole](https://github.com/kinginu/tt-splat)** ![community](https://img.shields.io/badge/community-27AE60?style=flat-square)
+  by [@kinginu](https://github.com/kinginu) — 3D Gaussian Splatting rewritten to run on the matrix engine: a polynomial splat and order-independent weighted-sum blending replace exp and depth-sorted alpha, so the pipeline becomes GEMM → activation → GEMM. Renderer + trainer, trained device-resident on a Blackhole p150a.
+  [📦 repo](https://github.com/kinginu/tt-splat)
+
 - **[tt-twitch](https://github.com/geohot/tt-twitch)** ![community](https://img.shields.io/badge/community-27AE60?style=flat-square)
   by [@geohot](https://github.com/geohot) — A Tenstorrent Grayskull kernel written live on Twitch by George Hotz. 120-core grid demonstration of live kernel programming.
   [📦 repo](https://github.com/geohot/tt-twitch)
@@ -474,6 +478,19 @@ A curated directory of projects, tools, models, and research for Tenstorrent har
 - **[tt-vscode-toolkit](https://github.com/tenstorrent/tt-vscode-toolkit)** ![official](https://img.shields.io/badge/official-607D8B?style=flat-square)
   48 interactive lessons covering the full Tenstorrent developer path — from hardware detection to custom training — with click-to-run commands and hardware auto-detection. Available in VSCode and code-server.
   [📦 repo](https://github.com/tenstorrent/tt-vscode-toolkit) · [📖 All 48 lessons](https://docs.tenstorrent.com/tt-vscode-toolkit/lessons) · [📖 RISC-V Programming Guide](https://docs.tenstorrent.com/tt-vscode-toolkit/riscv-guide/)
+
+## Feeds & Resources
+
+Subscribe to tt-awesome activity via Atom or JSON Feed:
+
+- **[New Entries (Atom)](https://tenstorrent.github.io/tt-awesome/feeds/new-entries.xml)** — newly added projects and resources.
+- **[Articles & Resources (Atom)](https://tenstorrent.github.io/tt-awesome/feeds/articles.xml)** — articles, papers, lessons, talks, and demos.
+- **[Recent Releases (Atom)](https://tenstorrent.github.io/tt-awesome/feeds/releases.xml)** — latest stable releases. Release items use LLM-generated summaries when available.
+- **[JSON Feed](https://tenstorrent.github.io/tt-awesome/feeds/feed.json)** — combined releases, entries, and articles (JSON Feed 1.1).
+- **[data.json](https://tenstorrent.github.io/tt-awesome/data.json)** — full machine-readable entry database.
+- **[llms.txt](https://tenstorrent.github.io/tt-awesome/llms.txt)** — curated plain-text index for LLM context and AI tooling.
+
+Each Atom and JSON Feed item carries both a short `<summary>` and a full rich `<content>` block containing the project description, all associated links, attribution, and tags — suitable for feed readers that render HTML content.
 
 ## Contributing
 

--- a/docs/superpowers/plans/2026-06-29-feed-content-and-llms-txt.md
+++ b/docs/superpowers/plans/2026-06-29-feed-content-and-llms-txt.md
@@ -1,0 +1,764 @@
+# Feed Content Enrichment & llms.txt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every RSS/Atom/JSON feed item a rich, markdown-formatted `<content>` block (links, attribution, tags) while keeping `<summary>` a clean one-liner, wire the existing LLM release summaries into the release feeds, and publish a curated `/llms.txt`.
+
+**Architecture:** Extend the tested JS filter layer in `.eleventy.js` (where `jsonFeedItems`/`articleFeedItems` already live) rather than Nunjucks. A single `feedContentHtml` builder produces the rich HTML block from one normalized object shape. Each data source (`entries`, `articleFeedItems` output, `recentReleases`) is shaped to conform to that contract, so every template just pipes `X | feedContentHtml`. Templates stay thin and everything is unit-testable through `tests/test_eleventy_filters.js`.
+
+**Tech Stack:** Eleventy (11ty), Nunjucks templates, `markdown-it`, Node's built-in `assert` for tests.
+
+## Global Constraints
+
+- License header on every new/modified source file (match existing):
+  `// SPDX-License-Identifier: Apache-2.0` and `// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.`
+- Markdown renderers MUST keep the existing safety posture: `new MarkdownIt({ html: false, linkify: false })` then `.disable("image")` — feeds carry untrusted external content; never emit `<img>` or raw HTML from source text.
+- All HTML attribute/text interpolation in `feedContentHtml` MUST be escaped via `mdBlock.utils.escapeHtml`. URLs are already validated as safe https in `entries.js`, but escape them anyway.
+- Site base URL for absolute links: `https://tenstorrent.github.io/tt-awesome/`.
+- Atom `<content>` and `<summary>` that contain HTML use `type="html"` and wrap the value in `<![CDATA[ ... ]]>` piped through the existing `cdataSafe` filter.
+- Tests are plain `node` scripts run with `node tests/test_eleventy_filters.js` (no test framework). Follow the existing stub-config harness at the top of that file.
+
+---
+
+### Task 1: `feedContentHtml` builder + block markdown renderer
+
+**Files:**
+- Modify: `.eleventy.js` (add `mdBlock` near the existing `mdInline` at lines 15-19; add `buildFeedContentHtml` function + `feedContentHtml` filter registration in the `addFilter` block)
+- Test: `tests/test_eleventy_filters.js`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `mdBlock` — module-scope `MarkdownIt` with block rendering (`.render()`), same safety config as `mdInline`.
+  - `buildFeedContentHtml(item)` — module-scope pure function returning an HTML string. Input shape (all fields optional except none required; missing → section omitted):
+    ```
+    { description: string, links: [{type, url, label}], author: string,
+      author_url: string, affiliation: string, tags: [string],
+      categories: [string], added_at: string }
+    ```
+  - `feedContentHtml` — Eleventy filter wrapping `buildFeedContentHtml`. Returns `""` for falsy input.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this block to `tests/test_eleventy_filters.js` just before the final `console.log("\nAll eleventy filter tests passed ✓");` line:
+
+```js
+// ── feedContentHtml tests ────────────────────────────────────────────────────
+const feedContentHtml = filters["feedContentHtml"];
+assert(typeof feedContentHtml === "function", "feedContentHtml filter not registered");
+{
+  const html = feedContentHtml({
+    description: "Boltz-2 on **Blackhole**.",
+    links: [
+      { type: "repo", url: "https://github.com/test/repo", label: "GitHub" },
+      { type: "article", url: "https://example.com/post" },
+    ],
+    author: "moritztng",
+    author_url: "https://github.com/moritztng",
+    affiliation: "community",
+    tags: ["blackhole", "drug-discovery"],
+    categories: ["ai-models"],
+    added_at: "2026-05-13",
+  });
+  // description rendered as block markdown
+  assert.ok(html.includes("<strong>Blackhole</strong>"), "renders markdown emphasis");
+  // links list with both links; missing label falls back to title-cased type
+  assert.ok(html.includes('<a href="https://github.com/test/repo">GitHub</a>'), "labeled link");
+  assert.ok(html.includes('<a href="https://example.com/post">Article</a>'), "fallback label is title-cased type");
+  // attribution: linked author handle, affiliation, added date
+  assert.ok(html.includes('<a href="https://github.com/moritztng">@moritztng</a>'), "linked author handle");
+  assert.ok(html.includes("community"), "affiliation present");
+  assert.ok(html.includes("2026-05-13"), "added date present");
+  // tags + categories
+  assert.ok(html.includes("blackhole") && html.includes("ai-models"), "tags + categories present");
+  console.log("✓ feedContentHtml: renders description, links, attribution, tags");
+}
+{
+  // Missing sections are omitted, not rendered empty.
+  const html = feedContentHtml({ description: "Just a description." });
+  assert.ok(html.includes("Just a description."), "description present");
+  assert.ok(!html.includes("<ul>"), "no links list when no links");
+  assert.ok(!html.includes("Links:"), "no Links heading when no links");
+  console.log("✓ feedContentHtml: omits absent sections");
+}
+{
+  // Escapes HTML in text fields and never emits an <img>.
+  const html = feedContentHtml({
+    description: "![x](http://evil/pixel.gif)",
+    author: "a<b>c",
+    links: [{ type: "repo", url: "https://x/y", label: "<script>" }],
+    tags: ["t&g"],
+  });
+  assert.ok(!html.includes("<img"), "no img from image markdown");
+  assert.ok(!html.includes("<script>"), "label HTML escaped");
+  assert.ok(html.includes("a&lt;b&gt;c"), "author HTML escaped");
+  assert.ok(html.includes("t&amp;g"), "tag ampersand escaped");
+  console.log("✓ feedContentHtml: escapes text fields, blocks images");
+}
+{
+  assert.strictEqual(feedContentHtml(null), "", "null input → empty string");
+  assert.strictEqual(feedContentHtml(undefined), "", "undefined input → empty string");
+  console.log("✓ feedContentHtml: empty input safe");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node tests/test_eleventy_filters.js`
+Expected: FAIL — `AssertionError: feedContentHtml filter not registered`.
+
+- [ ] **Step 3: Add the block markdown renderer**
+
+In `.eleventy.js`, immediately after the `mdInline.disable("image");` line (currently line 19), add:
+
+```js
+// Block-level markdown renderer for full feed <content> blocks. Same safety
+// posture as mdInline (no raw HTML, no auto-fetching images), but keeps block
+// wrappers so multi-paragraph release summaries render as real <p> tags.
+const mdBlock = new MarkdownIt({ html: false, linkify: false });
+mdBlock.disable("image");
+
+// Shared HTML escaper for text we interpolate directly into the content block.
+const escapeHtml = mdBlock.utils.escapeHtml;
+
+// Build the rich HTML <content> block shared by every feed (Atom <content
+// type="html"> and JSON Feed content_html). Sections whose data is absent are
+// omitted entirely. Accepts a single normalized object — see plan Task 1.
+function buildFeedContentHtml(item) {
+  if (!item) return "";
+  const parts = [];
+
+  // 1. Description / summary — block markdown (paragraphs preserved).
+  if (item.description) parts.push(mdBlock.render(item.description));
+
+  // 2. Links — every typed link as a labeled anchor. Label falls back to a
+  //    title-cased link type (e.g. "article" → "Article").
+  const links = (item.links || []).filter((l) => l && l.url);
+  if (links.length) {
+    const lis = links
+      .map((l) => {
+        const label = l.label
+          ? escapeHtml(l.label)
+          : l.type
+          ? escapeHtml(l.type.charAt(0).toUpperCase() + l.type.slice(1))
+          : escapeHtml(l.url);
+        return `<li><a href="${escapeHtml(l.url)}">${label}</a></li>`;
+      })
+      .join("");
+    parts.push(`<p><strong>Links:</strong></p>\n<ul>${lis}</ul>`);
+  }
+
+  // 3. Attribution — author (linked when we have a profile URL), affiliation,
+  //    date added, separated by middots.
+  const attr = [];
+  if (item.author) {
+    attr.push(
+      item.author_url
+        ? `By <a href="${escapeHtml(item.author_url)}">@${escapeHtml(item.author)}</a>`
+        : `By @${escapeHtml(item.author)}`
+    );
+  }
+  if (item.affiliation) attr.push(escapeHtml(item.affiliation));
+  if (item.added_at) attr.push(`added ${escapeHtml(item.added_at)}`);
+  if (attr.length) parts.push(`<p>${attr.join(" · ")}</p>`);
+
+  // 4. Tags + categories — comma-separated, emphasized.
+  const tagBits = [...(item.tags || []), ...(item.categories || [])];
+  if (tagBits.length) {
+    parts.push(`<p><em>${tagBits.map(escapeHtml).join(", ")}</em></p>`);
+  }
+
+  return parts.join("\n");
+}
+```
+
+- [ ] **Step 4: Register the filter**
+
+In `.eleventy.js`, inside `module.exports = function (eleventyConfig) { ... }`, add after the `markdownInline` filter registration (currently ends at line 38):
+
+```js
+  // Render the full rich HTML content block for a feed item. Pair with
+  // `| cdataSafe | safe` in Atom templates. See buildFeedContentHtml above.
+  eleventyConfig.addFilter("feedContentHtml", (item) => buildFeedContentHtml(item));
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `node tests/test_eleventy_filters.js`
+Expected: PASS — all four new `✓ feedContentHtml:` lines print, no assertion errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .eleventy.js tests/test_eleventy_filters.js
+git commit -m "feat: add feedContentHtml builder for rich feed content blocks"
+```
+
+---
+
+### Task 2: Resolve rich release summaries in `recentReleases.js`
+
+**Files:**
+- Modify: `src/_data/recentReleases.js`
+- Test: `tests/test_eleventy_filters.js`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (independent of Task 1).
+- Produces:
+  - `resolveReleaseSummary(rel, planetFeeds)` — module-scope pure function, exported as `module.exports.resolveReleaseSummary`. Returns the matched planet-feed `description` (rich text), else the fallback string `"{entryName} released {tagName}. Repository: {repoUrl}"`.
+  - Each item returned by `recentReleases()` gains: `summary` (string), `description` (= summary, for `feedContentHtml`), `links` (`[{type:"repo",...},{type:"release",...}]`), `added_at` (`publishedAt` truncated to `YYYY-MM-DD`). Existing fields are unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new test module `tests/test_recent_releases.js`:
+
+```js
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+
+// Tests for resolveReleaseSummary in src/_data/recentReleases.js.
+// Run with: node tests/test_recent_releases.js
+const assert = require("assert");
+const { resolveReleaseSummary } = require("../src/_data/recentReleases.js");
+
+assert(typeof resolveReleaseSummary === "function", "resolveReleaseSummary not exported");
+
+const rel = {
+  entryName: "tt-forge-onnx",
+  tagName: "1.3.0",
+  repoUrl: "https://github.com/tenstorrent/tt-forge-onnx",
+  url: "https://github.com/tenstorrent/tt-forge-onnx/releases/tag/1.3.0",
+};
+
+// Exact URL match → rich description.
+{
+  const feeds = [
+    { type: "release", url: rel.url, description: "Rich synchronized-updates summary." },
+  ];
+  assert.strictEqual(resolveReleaseSummary(rel, feeds), "Rich synchronized-updates summary.");
+  console.log("✓ resolveReleaseSummary: exact URL match returns rich description");
+}
+
+// Same-repo /releases/ + tag match (URLs differ slightly) → rich description.
+{
+  const feeds = [
+    {
+      type: "release",
+      url: "https://github.com/tenstorrent/tt-forge-onnx/releases/1.3.0",
+      description: "Fuzzy-matched summary.",
+    },
+  ];
+  assert.strictEqual(resolveReleaseSummary(rel, feeds), "Fuzzy-matched summary.");
+  console.log("✓ resolveReleaseSummary: same-repo + tag fallback match");
+}
+
+// No match → fallback string.
+{
+  const feeds = [
+    { type: "release", url: "https://github.com/other/repo/releases/tag/9.9.9", description: "Unrelated." },
+  ];
+  assert.strictEqual(
+    resolveReleaseSummary(rel, feeds),
+    "tt-forge-onnx released 1.3.0. Repository: https://github.com/tenstorrent/tt-forge-onnx"
+  );
+  console.log("✓ resolveReleaseSummary: no match returns fallback string");
+}
+
+// Missing/empty feeds → fallback (does not throw).
+{
+  assert.strictEqual(
+    resolveReleaseSummary(rel, []),
+    "tt-forge-onnx released 1.3.0. Repository: https://github.com/tenstorrent/tt-forge-onnx"
+  );
+  assert.strictEqual(
+    resolveReleaseSummary(rel, undefined),
+    "tt-forge-onnx released 1.3.0. Repository: https://github.com/tenstorrent/tt-forge-onnx"
+  );
+  console.log("✓ resolveReleaseSummary: empty/undefined feeds safe");
+}
+
+// Non-release feed items are ignored.
+{
+  const feeds = [{ type: "article", url: rel.url, description: "Should be ignored." }];
+  assert.ok(resolveReleaseSummary(rel, feeds).startsWith("tt-forge-onnx released"),
+    "non-release items ignored");
+  console.log("✓ resolveReleaseSummary: ignores non-release feed items");
+}
+
+console.log("\nAll recentReleases tests passed ✓");
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node tests/test_recent_releases.js`
+Expected: FAIL — `AssertionError: resolveReleaseSummary not exported` (or a `TypeError` on the destructure).
+
+- [ ] **Step 3: Implement the resolver and enrich items**
+
+In `src/_data/recentReleases.js`, add `fs`/`path` requires at the top (after the license header) and the resolver function above `module.exports`:
+
+```js
+const fs = require("fs");
+const path = require("path");
+
+// Load planet_feeds.json (the source of LLM-generated release summaries).
+// Returns [] when absent (first build before the nightly summarize job runs).
+function loadPlanetFeeds() {
+  const p = path.join(__dirname, "planet_feeds.json");
+  if (!fs.existsSync(p)) return [];
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch (_) {
+    return [];
+  }
+}
+
+// Resolve a human-quality summary for a release. Prefers the LLM-generated
+// description from planet_feeds.json (matched by exact release URL, then by
+// same-repo /releases/ path + tag name), falling back to a terse one-liner.
+function resolveReleaseSummary(rel, planetFeeds) {
+  const feeds = planetFeeds || [];
+  // 1. Exact URL match.
+  for (const item of feeds) {
+    if (item.type !== "release" || !item.description) continue;
+    if (item.url === rel.url) return item.description;
+  }
+  // 2. Same-repo release whose URL carries the same tag (handles html_url vs
+  //    tag-url shape differences between GitHub's API and the summarizer).
+  if (rel.repoUrl && rel.tagName) {
+    const prefix = rel.repoUrl + "/releases/";
+    for (const item of feeds) {
+      if (item.type !== "release" || !item.description || !item.url) continue;
+      if (item.url.startsWith(prefix) && item.url.includes(rel.tagName)) {
+        return item.description;
+      }
+    }
+  }
+  // 3. Fallback one-liner.
+  return `${rel.entryName} released ${rel.tagName}.` +
+    (rel.repoUrl ? ` Repository: ${rel.repoUrl}` : "");
+}
+```
+
+Then, inside the existing `module.exports = function () { ... }`, after the `releases.push({...})` loop populates each release but before the final `sort`, enrich each item. Replace the existing `releases.push({ ... })` call so it also captures what we need, then add enrichment after the loop:
+
+```js
+  const planetFeeds = loadPlanetFeeds();
+  for (const rel of releases) {
+    rel.summary = resolveReleaseSummary(rel, planetFeeds);
+    // Conform to the feedContentHtml contract (see .eleventy.js Task 1):
+    rel.description = rel.summary;
+    rel.added_at = rel.publishedAt ? rel.publishedAt.slice(0, 10) : "";
+    rel.links = [
+      rel.repoUrl ? { type: "repo", url: rel.repoUrl, label: "Repository" } : null,
+      rel.url ? { type: "release", url: rel.url, label: rel.tagName } : null,
+    ].filter(Boolean);
+  }
+```
+
+Finally, at the very bottom of the file (after `module.exports = function ...`), export the resolver for testing:
+
+```js
+module.exports.resolveReleaseSummary = resolveReleaseSummary;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node tests/test_recent_releases.js`
+Expected: PASS — all five `✓ resolveReleaseSummary:` lines print.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/_data/recentReleases.js tests/test_recent_releases.js
+git commit -m "feat: resolve rich LLM release summaries in recentReleases"
+```
+
+---
+
+### Task 3: Wire rich content into the JSON feed (`jsonFeedItems`)
+
+**Files:**
+- Modify: `.eleventy.js` (the `jsonFeedItems` filter, lines 174-253)
+- Test: `tests/test_eleventy_filters.js`
+
+**Interfaces:**
+- Consumes: `buildFeedContentHtml` (Task 1); `rel.summary` (Task 2).
+- Produces: each JSON Feed item's `content_html` is now the rich block; release items' `summary` is `rel.summary`.
+
+- [ ] **Step 1: Update the existing failing test (Test 9b)**
+
+In `tests/test_eleventy_filters.js`, find Test 9b (the `✓ jsonFeedItems: items carry rendered content_html + plain summary` block). Replace its two `content_html` assertions so they expect the rich block instead of a bare inline render:
+
+```js
+  // content_html is now the rich block — it CONTAINS the rendered description.
+  assert.ok(entryItem.content_html.includes("<code>tt_metal</code>"),
+    "content_html renders the description as markdown");
+  assert.strictEqual(entryItem.summary, "Uses `tt_metal` under the hood.",
+    "summary stays plain text");
+  assert.ok(items.every((i) => typeof i.content_html === "string"),
+    "every item has content_html");
+```
+
+Also add a new release-summary assertion right after Test 8 (`✓ jsonFeedItems: release items have correct shape`):
+
+```js
+// Test 8b: release items use rel.summary as their summary text.
+{
+  const rel = makeRelease({ summary: "Rich release summary here." });
+  const items = jsonFeedItems([], [rel]);
+  assert.strictEqual(items[0].summary, "Rich release summary here.",
+    "release summary comes from rel.summary");
+  assert.ok(items[0].content_html.includes("Rich release summary here."),
+    "release content_html renders the summary");
+  console.log("✓ jsonFeedItems: release items use rel.summary");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node tests/test_eleventy_filters.js`
+Expected: FAIL — Test 9b assertion `content_html renders the description as markdown` fails (current code sets `content_html` to the bare inline render, which equals `Uses <code>tt_metal</code> under the hood.` and DOES include `<code>tt_metal</code>` — so this passes — but Test 8b fails because `rel.summary` is undefined in current code and summary is the computed one-liner). Confirm Test 8b fails with a summary mismatch.
+
+- [ ] **Step 3: Update `jsonFeedItems`**
+
+In `.eleventy.js`, in the `jsonFeedItems` filter:
+
+(a) Release items (the first `for (const rel of recentReleases || [])` loop) — replace the body so summary/content use the resolved fields:
+
+```js
+    for (const rel of recentReleases || []) {
+      const summary = rel.summary ||
+        `${rel.entryName} released ${rel.tagName}. Repository: ${rel.repoUrl}`;
+      items.push({
+        id:             rel.url,
+        url:            rel.url,
+        title:          `${rel.entryName} ${rel.tagName}`,
+        content_html:   buildFeedContentHtml(rel),
+        summary:        summary,
+        date_published: rel.publishedAt,
+        tags:           [rel.affiliation, "release"].filter(Boolean),
+      });
+    }
+```
+
+(b) Entry items (the `2a.` push) — set `content_html` to the rich block:
+
+```js
+        content_html:   buildFeedContentHtml(entry),
+```
+
+(c) Article-link items (the `2b.` push) — same: the entry conforms to the contract, so render its block:
+
+```js
+          content_html:   buildFeedContentHtml(entry),
+```
+
+Leave every `summary:` field as-is (entry/article summary stays `entry.description`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node tests/test_eleventy_filters.js`
+Expected: PASS — `✓ jsonFeedItems: release items use rel.summary` and all existing jsonFeedItems lines print.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .eleventy.js tests/test_eleventy_filters.js
+git commit -m "feat: rich content_html + LLM release summaries in JSON feed"
+```
+
+---
+
+### Task 4: Extend `articleFeedItems` to carry content-block fields
+
+**Files:**
+- Modify: `.eleventy.js` (the `articleFeedItems` filter, lines 128-160)
+- Test: `tests/test_eleventy_filters.js`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: each `articleFeedItems` output object additionally carries `description` (= entry description), `links` (entry's full links array), `author`, `author_url`, `tags` — so the object conforms to the `feedContentHtml` contract. Existing fields (`entryId`, `entryName`, `entryDesc`, `affiliation`, `categories`, `linkType`, `linkUrl`, `linkLabel`, `added_at`) are unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Add after the existing articleFeedItems tests (before the jsonFeedItems section) in `tests/test_eleventy_filters.js`:
+
+```js
+// articleFeedItems carries fields needed by feedContentHtml.
+{
+  const entry = makeEntry({
+    author: "alice",
+    author_url: "https://github.com/alice",
+    tags: ["blackhole"],
+    links: [
+      { type: "repo", url: "https://github.com/test/repo" },
+      { type: "article", url: "https://example.com/article", label: "Read more" },
+    ],
+  });
+  const items = articleFeedItems([entry], 50);
+  const it = items[0];
+  assert.strictEqual(it.description, "A test entry.", "carries entry description");
+  assert.strictEqual(it.author, "alice", "carries author");
+  assert.strictEqual(it.author_url, "https://github.com/alice", "carries author_url");
+  assert.deepStrictEqual(it.tags, ["blackhole"], "carries tags");
+  assert.strictEqual(it.links.length, 2, "carries entry's full links array");
+  console.log("✓ articleFeedItems: carries feedContentHtml contract fields");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node tests/test_eleventy_filters.js`
+Expected: FAIL — `it.description` is `undefined` (current code only sets `entryDesc`).
+
+- [ ] **Step 3: Add the fields to the pushed object**
+
+In `.eleventy.js`, in the `articleFeedItems` filter, extend the `items.push({ ... })` object with the contract fields (keep all existing keys):
+
+```js
+        items.push({
+          entryId:    entry.id,
+          entryName:  entry.name,
+          entryDesc:  entry.description || "",
+          affiliation: entry.affiliation || "",
+          categories: entry.categories || [],
+          linkType:   link.type,
+          linkUrl:    link.url,
+          linkLabel:  link.label || (link.type.charAt(0).toUpperCase() + link.type.slice(1)),
+          added_at:   entry.added_at || "1970-01-01",
+          // feedContentHtml contract fields:
+          description: entry.description || "",
+          links:      entry.links || [],
+          author:     entry.author || "",
+          author_url: entry.author_url || "",
+          tags:       entry.tags || [],
+        });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node tests/test_eleventy_filters.js`
+Expected: PASS — `✓ articleFeedItems: carries feedContentHtml contract fields`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .eleventy.js tests/test_eleventy_filters.js
+git commit -m "feat: carry content-block fields through articleFeedItems"
+```
+
+---
+
+### Task 5: Add `<content>` to the three Atom feeds
+
+**Files:**
+- Modify: `src/feeds/new-entries.njk`
+- Modify: `src/feeds/articles.njk`
+- Modify: `src/feeds/releases.njk`
+
+**Interfaces:**
+- Consumes: `feedContentHtml` filter (Task 1); `recentReleases` items conforming to the contract (Task 2); `articleFeedItems` items conforming to the contract (Task 4); entries already conform.
+- Produces: each Atom `<entry>` now has a `<content type="html">` alongside its existing `<summary>`.
+
+No unit test — verified by a full build (Step 4) and feed validity check.
+
+- [ ] **Step 1: `new-entries.xml` — add `<content>` after `<summary>`**
+
+In `src/feeds/new-entries.njk`, after the existing `<summary ...>` line (line 25) and before `<category term="{{ entry.affiliation }}"/>`, add:
+
+```njk
+    {#- Full rich content block for feed readers; summary above stays a clean
+        one-liner so Slack's RSS app (which flattens HTML) still reads well. #}
+    <content type="html"><![CDATA[{{ entry | feedContentHtml | cdataSafe | safe }}]]></content>
+```
+
+- [ ] **Step 2: `articles.xml` — add `<content>` after `<summary>`**
+
+In `src/feeds/articles.njk`, after the existing `<summary ...>` line (line 23) and before `<category term="{{ item.linkType }}"/>`, add:
+
+```njk
+    <content type="html"><![CDATA[{{ item | feedContentHtml | cdataSafe | safe }}]]></content>
+```
+
+- [ ] **Step 3: `releases.xml` — use rich summary + add `<content>`**
+
+In `src/feeds/releases.njk`, replace the existing `<summary>` line (line 22):
+
+```njk
+    <summary>{{ rel.entryName }} released {{ rel.tagName }}. Repository: {{ rel.repoUrl }}</summary>
+```
+
+with the resolved summary (kept as plain text so Slack reads cleanly) plus a content block:
+
+```njk
+    <summary type="html"><![CDATA[{{ rel.summary | markdownInline | cdataSafe | safe }}]]></summary>
+    <content type="html"><![CDATA[{{ rel | feedContentHtml | cdataSafe | safe }}]]></content>
+```
+
+- [ ] **Step 4: Build and verify all three feeds render**
+
+Run: `npm run build`
+Expected: build completes with no errors. Then verify each feed contains a `<content` element and is well-formed:
+
+```bash
+grep -c "<content" _site/feeds/new-entries.xml _site/feeds/articles.xml _site/feeds/releases.xml
+```
+Expected: each file reports a count ≥ 1 (one `<content>` per entry).
+
+Verify XML well-formedness (catches an unescaped/early-closed CDATA):
+
+```bash
+for f in new-entries articles releases; do xmllint --noout "_site/feeds/$f.xml" && echo "$f ok"; done
+```
+Expected: `new-entries ok`, `articles ok`, `releases ok` with no parse errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feeds/new-entries.njk src/feeds/articles.njk src/feeds/releases.njk
+git commit -m "feat: add rich <content> blocks to Atom feeds"
+```
+
+---
+
+### Task 6: Add the `/llms.txt` template
+
+**Files:**
+- Create: `src/llms-txt.njk`
+
+**Interfaces:**
+- Consumes: the `entries` and `categories` Eleventy data globals (already used by `src/index.njk`).
+- Produces: `/llms.txt` at the site root.
+
+No unit test — verified by build (Step 3).
+
+- [ ] **Step 1: Inspect the categories data shape**
+
+Run: `node -e "console.log(JSON.stringify(require('./src/_data/categories.js')().slice(0,2),null,2))" 2>/dev/null || node -e "console.log(JSON.stringify(require('./src/_data/categories.js').slice(0,2),null,2))"`
+Expected: prints category objects. Confirm each has a `slug`, a display `name` (or `title`), and note the exact property names for use in Step 2. (If the export is an array, the second command prints; if a function, the first.)
+
+- [ ] **Step 2: Create the template**
+
+Create `src/llms-txt.njk`. Use the property names confirmed in Step 1 (this plan assumes `cat.slug` and `cat.name`; adjust if Step 1 shows `cat.title`):
+
+```njk
+---
+permalink: /llms.txt
+eleventyExcludeFromCollections: true
+---
+# tt-awesome
+
+> A curated directory of projects, tools, models, and research for Tenstorrent hardware — contributed by the community and the Tenstorrent team. Generated from the entries in this repository.
+
+## Feeds & Data
+
+- [JSON Feed](https://tenstorrent.github.io/tt-awesome/feeds/feed.json): combined releases, entries, and articles (JSON Feed 1.1).
+- [New Entries (Atom)](https://tenstorrent.github.io/tt-awesome/feeds/new-entries.xml): newly added projects and resources.
+- [Articles & Resources (Atom)](https://tenstorrent.github.io/tt-awesome/feeds/articles.xml): articles, papers, lessons, talks, videos, demos.
+- [Recent Releases (Atom)](https://tenstorrent.github.io/tt-awesome/feeds/releases.xml): latest stable releases.
+- [data.json](https://tenstorrent.github.io/tt-awesome/data.json): the full machine-readable entry database.
+- [README](https://github.com/tenstorrent/tt-awesome/blob/main/README.md): human-readable directory.
+{% for cat in categories %}
+## {{ cat.name }}
+{% for entry in entries | sort(false, false, "name") %}{% if entry.categories and (cat.slug in entry.categories) %}{%- set repoLink = entry.links | selectattr("type", "equalto", "repo") | first %}{%- set anyLink = entry.links | first %}
+- [{{ entry.name }}]({{ repoLink.url if repoLink else (anyLink.url if anyLink else "https://tenstorrent.github.io/tt-awesome/#" + entry.id) }}): {{ entry.description | striptags | replace("\n", " ") }}
+{%- endif %}{% endfor %}
+{% endfor %}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `npm run build`
+Expected: build completes; `_site/llms.txt` exists.
+
+```bash
+head -20 _site/llms.txt
+```
+Expected: starts with `# tt-awesome`, the blockquote summary, a `## Feeds & Data` section, then `## <Category>` sections with `- [name](url): description` bullets. Confirm no `[object Object]` or empty `()` links.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/llms-txt.njk
+git commit -m "feat: publish curated /llms.txt site index"
+```
+
+---
+
+### Task 7: Document the feed enrichment and llms.txt in the README
+
+**Files:**
+- Modify: `README.md` (the feeds section)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Locate the feeds section**
+
+Run: `grep -n "feeds/\|feed.json\|Atom\|RSS\|llms" README.md | head -20`
+Expected: line numbers for the existing feeds documentation. Note the section heading.
+
+- [ ] **Step 2: Update the feeds documentation**
+
+In the feeds section of `README.md`, update the description so it states that:
+- Each Atom/JSON item now carries a full rich `<content>` block (description, links, attribution, tags) in addition to a short `<summary>`;
+- Release feed items use the LLM-generated release summaries when available;
+- A curated `/llms.txt` index is published at `https://tenstorrent.github.io/tt-awesome/llms.txt`.
+
+Add an `llms.txt` bullet to the feeds/resources list using the same style as the existing feed bullets (match the surrounding markdown — do not invent a new format). Keep wording factual and concise.
+
+- [ ] **Step 3: Verify the README still generates cleanly (if applicable)**
+
+Run: `grep -n "llms.txt" README.md`
+Expected: the new bullet appears. (The README's auto-generated entry list is produced by `scripts/generate_readme.py`; this edit is to the hand-written feeds section only — do not edit the auto-generated entry blocks.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document rich feed content and /llms.txt"
+```
+
+---
+
+### Task 8: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run all JS tests**
+
+Run: `node tests/test_eleventy_filters.js && node tests/test_recent_releases.js`
+Expected: both end with `All ... tests passed ✓`, no assertion errors.
+
+- [ ] **Step 2: Run the Python test suite (unchanged, confirm no regressions)**
+
+Run: `python3 -m pytest tests/ -q`
+Expected: all pass (this change does not touch Python, so the suite should be green).
+
+- [ ] **Step 3: Full build + feed validity**
+
+Run: `npm run build && for f in new-entries articles releases; do xmllint --noout "_site/feeds/$f.xml" && echo "$f ok"; done && node -e "JSON.parse(require('fs').readFileSync('_site/feeds/feed.json','utf8')); console.log('feed.json ok')" && test -f _site/llms.txt && echo "llms.txt ok"`
+Expected: `new-entries ok`, `articles ok`, `releases ok`, `feed.json ok`, `llms.txt ok`.
+
+- [ ] **Step 4: Spot-check rendered content**
+
+Run: `grep -A2 "<content" _site/feeds/releases.xml | head -20`
+Expected: a release `<content>` block containing the rich LLM summary text (for a release that has one in `planet_feeds.json`), a `Links:` list, and an affiliation line.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Rich release summaries wired into releases.xml + feed.json → Tasks 2, 3, 5. ✓
+- `feedContentHtml` block (description, links, attribution, tags/categories) → Task 1. ✓
+- summary vs content / graceful degradation → Tasks 3 (JSON), 5 (Atom; summary stays clean). ✓
+- All four feeds enriched → Task 3 (feed.json) + Task 5 (three Atom feeds). ✓
+- llms.txt curated, category-organized → Task 6. ✓
+- Tests for feedContentHtml + recentReleases + jsonFeedItems → Tasks 1, 2, 3, 4. ✓
+- README docs → Task 7. ✓
+- Out of scope (stars/release stats in block, llms-full.txt) → not present. ✓
+
+**Placeholder scan:** No TBD/TODO; all code blocks complete. Task 6 Step 1 explicitly resolves the one unknown (categories property names) before writing the template, and Task 6 Step 2 notes the fallback. ✓
+
+**Type consistency:** `buildFeedContentHtml(item)` contract is defined in Task 1 and every producer (entries — native; `recentReleases` — Task 2; `articleFeedItems` — Task 4) is shaped to it. `resolveReleaseSummary(rel, planetFeeds)` signature is consistent between Task 2 definition and its test. `rel.summary` produced in Task 2, consumed in Task 3. ✓

--- a/docs/superpowers/specs/2026-06-29-feed-content-and-llms-txt-design.md
+++ b/docs/superpowers/specs/2026-06-29-feed-content-and-llms-txt-design.md
@@ -45,10 +45,12 @@ Rule: `<summary>` = clean one-liner; `<content>` = full rich HTML block.
 
 Feed logic already lives in tested JS filters in `.eleventy.js`
 (`jsonFeedItems`, `articleFeedItems`) with thin Nunjucks templates. We extend
-that filter layer rather than pushing logic into Nunjucks, which the codebase
-already documents as unreliable for this kind of work (see comments in
-`entries.js` re: `selectattr` / loop-scope). Everything stays unit-testable
-through the existing `tests/test_eleventy_filters.js` harness.
+that filter layer rather than pushing logic into Nunjucks. In Eleventy's
+Nunjucks `selectattr` exists but filters unreliably (see the `planetCount`
+comment in `.eleventy.js`), and loop-scoped variables don't persist to the
+outer scope (see `entries.js`) — so link selection and similar logic belong in
+JS filters, where they're predictable and unit-testable through the existing
+`tests/test_eleventy_filters.js` harness.
 
 ### Component 1 — Rich release summaries in `recentReleases.js`
 

--- a/docs/superpowers/specs/2026-06-29-feed-content-and-llms-txt-design.md
+++ b/docs/superpowers/specs/2026-06-29-feed-content-and-llms-txt-design.md
@@ -1,0 +1,184 @@
+# Feed Content Enrichment & llms.txt — Design
+
+**Date:** 2026-06-29
+**Branch:** `improvements/rss_and_atom`
+**Status:** Approved (design)
+
+## Problem
+
+The site publishes four feeds, but every item carries only a short one-line
+`<summary>` (the entry's description rendered as inline markdown). Three gaps:
+
+1. **Releases are impoverished.** Rich, LLM-generated release summaries already
+   exist in `src/_data/planet_feeds.json` (e.g. the multi-sentence tt-forge-onnx
+   1.3.0 writeup produced by `scripts/summarize_releases.py`), but
+   `feeds/releases.xml` and the release items in `feeds/feed.json` ignore them in
+   favor of the boring string `"{name} released {tag}. Repository: {url}"`.
+2. **No full content.** Atom and JSON Feed both distinguish a short `<summary>`
+   from a full `<content>` / `content_html`. We only ever emit summary, so the
+   author, typed links, tags, and categories that already live in every entry
+   are wasted in the feed.
+3. **No `llms.txt`.** There is no machine-navigable index for LLMs at `/llms.txt`
+   (per llmstxt.org), despite the site being a curated directory ideally suited
+   to one.
+
+## Goals
+
+- Wire the existing rich release summaries into both `releases.xml` and `feed.json`.
+- Add a full, markdown-formatted `<content>` block to every feed item, while
+  keeping `<summary>` a clean one-liner so it degrades gracefully.
+- Publish a curated, category-organized `/llms.txt`.
+
+## Consumption target: degrade gracefully
+
+The feeds serve two audiences and the design must satisfy both:
+
+- **General feed readers** (NetNewsWire, Feedly, Reeder) render full HTML
+  `<content>` — links, lists, bold. This is where the rich block shines.
+- **Slack's RSS app** strips most HTML and shows title + a plain-text snippet
+  drawn from the summary. So `<summary>` must stay clean, meaningful text and
+  never depend on HTML structure to make sense.
+
+Rule: `<summary>` = clean one-liner; `<content>` = full rich HTML block.
+
+## Architecture
+
+Feed logic already lives in tested JS filters in `.eleventy.js`
+(`jsonFeedItems`, `articleFeedItems`) with thin Nunjucks templates. We extend
+that filter layer rather than pushing logic into Nunjucks, which the codebase
+already documents as unreliable for this kind of work (see comments in
+`entries.js` re: `selectattr` / loop-scope). Everything stays unit-testable
+through the existing `tests/test_eleventy_filters.js` harness.
+
+### Component 1 — Rich release summaries in `recentReleases.js`
+
+`src/_data/recentReleases.js` gains a `summary` field per release item, resolved
+from `planet_feeds.json`:
+
+- Load `planet_feeds.json` via the existing `planetFeeds` loader pattern
+  (`fs.existsSync` guard; return `[]` when absent — first build before nightly).
+- Build a lookup from the `release`-type planet-feed items. Match a release to a
+  summary by:
+  1. Exact `url` match, then
+  2. Fallback: the planet item's `url` starts with `{repoUrl}/releases/`
+     (the same heuristic already proven in the `planetItems` filter).
+- `summary` = matched planet-feed `description` (rich text) when found, else the
+  existing fallback string `"{entryName} released {tagName}. Repository: {repoUrl}"`.
+
+Because `releases.xml` reads `recentReleases` directly and `jsonFeedItems`
+receives it as an argument, **both feeds get rich summaries from this one change.**
+`jsonFeedItems` is updated to read `rel.summary` instead of recomputing the
+fallback string inline.
+
+### Component 2 — `feedContentHtml` filter
+
+New filter in `.eleventy.js`. Output: an HTML string suitable for Atom
+`<content type="html">` (wrapped in CDATA by the template) and JSON `content_html`.
+
+**Input contract.** `feedContentHtml` accepts a single normalized object and
+never reaches back into other globals:
+
+```
+{
+  description: string,   // markdown; the rich summary or entry description
+  links:       [{type, url, label}],   // all typed links to render
+  author:      string?,  // bare handle, no "@"
+  author_url:  string?,
+  affiliation: string?,
+  tags:        [string]?,
+  categories:  [string]?,
+  added_at:    string?,  // YYYY-MM-DD
+}
+```
+
+- **`new-entries.xml`** passes the raw `entry` — it already has `links`,
+  `author`, `author_url`, `tags`, `categories`, `added_at`. Compatible as-is.
+- **`articles.xml`** — `articleFeedItems` is extended to carry the *entry's full*
+  `links` array plus `author` / `author_url` (it already carries `entryDesc`,
+  `affiliation`, `categories`, `added_at`). The template maps these onto the
+  contract. `tags` is included when present on the entry.
+- **`releases.xml`** — the template builds the contract object inline:
+  `description` = the resolved rich `rel.summary`; `links` = repo + release-page
+  links; `affiliation` from the release; `added_at` from `publishedAt`.
+- **`feed.json`** — `jsonFeedItems` builds the same contract object per item and
+  calls the shared builder so HTML matches the Atom feeds exactly.
+
+Block structure (sections omitted when their data is absent):
+
+1. **Description / summary** — rendered with a new block-level markdown renderer
+   (`mdBlock`), so multi-paragraph release summaries get real `<p>` tags. Inline
+   one-liners render as a single paragraph.
+2. **Links** — `<p><strong>Links:</strong></p><ul>` of every typed link as
+   `<a href="url">label</a>`. Label falls back to a title-cased type. Includes
+   repo, website, article, paper, talk, video, demo.
+3. **Attribution** — a line with author (`@handle`, linked to `author_url` when
+   present), affiliation, and date added.
+4. **Tags + categories** — comma-separated topic tags and category slugs.
+
+A new `mdBlock = new MarkdownIt({ html: false, linkify: false })` with
+`mdBlock.disable("image")` mirrors the existing `mdInline` safety posture
+(escape raw HTML, no auto-fetching images) but keeps block wrappers. The link
+list and metadata are emitted as literal, already-escaped HTML (URLs validated
+upstream in `entries.js` via `isSafeHttpsUrl`; link/tag/author text escaped to
+neutralize `<`, `>`, `&`).
+
+### Component 3 — Template wiring
+
+- **`feeds/new-entries.xml`** — keep existing `<summary type="html">` (clean
+  inline description); add `<content type="html"><![CDATA[{{ entry | feedContentHtml | cdataSafe | safe }}]]></content>`.
+- **`feeds/articles.xml`** — same: keep `<summary>`, add `<content>` built from
+  the article-link item context.
+- **`feeds/releases.xml`** — `<summary>` becomes the resolved `rel.summary`
+  one-liner/rich text (clean); add `<content>` built from the release context
+  (rich summary as paragraphs + repo/release links + affiliation).
+- **`feeds/feed.json`** — `jsonFeedItems` sets `content_html` to the
+  `feedContentHtml` block and keeps `summary` as the clean text per item type.
+
+### Component 4 — `llms.txt`
+
+New template `src/llms-txt.njk`, `permalink: /llms.txt`,
+`eleventyExcludeFromCollections: true`. Built from `entries` + `categories`:
+
+- `# tt-awesome` + a blockquote one-line summary of the directory.
+- `## Feeds & Data` — links to the four feeds, `data.json`, and the README.
+- One `##` section per category (using `categories` for title + slug), each a
+  bulleted list of `- [name](url): description` for entries in that category.
+  Prefer the repo link; fall back to first link or the homepage anchor. Trim
+  description to a single line. Entries appear under each of their categories.
+
+Generated at build time alongside the feeds, so it stays current automatically.
+Follows the llmstxt.org structure (H1, blockquote, then `##` link sections).
+
+## Out of scope
+
+- Repo stars / latest-release stats inside the content block.
+- A separate `llms-full.txt` dump.
+- Any change to how `planet_feeds.json` / summaries are generated.
+
+## Testing
+
+Extend `tests/test_eleventy_filters.js` (plain `node` + `assert`, capturing
+filters from the stub config — existing pattern):
+
+- `feedContentHtml`:
+  - emits a Links list containing every typed link with correct labels;
+  - emits the attribution line (author handle, affiliation, date);
+  - emits tags + categories;
+  - omits sections whose data is absent (no links / no author / no tags);
+  - escapes `<`, `>`, `&` in text fields; never emits an `<img>`.
+- `recentReleases` summary resolution:
+  - exact-URL match attaches the rich planet-feed description;
+  - `{repoUrl}/releases/` fallback match works;
+  - no match falls back to the `"{name} released {tag}"` string;
+  - missing `planet_feeds.json` does not throw (returns fallback).
+- `jsonFeedItems`: release items now carry `rel.summary` in `summary`, and
+  `content_html` is the rich block; entry/article items carry the rich block in
+  `content_html` and clean text in `summary`.
+
+Run: `node tests/test_eleventy_filters.js` and a full `npm run build` to confirm
+all four feeds and `/llms.txt` render as valid output.
+
+## Docs
+
+Update the README feeds section to document the `<content>` enrichment and the
+new `/llms.txt` resource.

--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -180,6 +180,28 @@ def generate():
         for e in cat_entries:
             lines += [render_entry(e), ""]
 
+    # Feeds & Resources section — hand-authored content kept in generate() so it
+    # survives re-generation.  Update this block when feed capabilities change.
+    lines += [
+        "## Feeds & Resources", "",
+        "Subscribe to tt-awesome activity via Atom or JSON Feed:", "",
+        "- **[New Entries (Atom)](https://tenstorrent.github.io/tt-awesome/feeds/new-entries.xml)** — "
+        "newly added projects and resources.",
+        "- **[Articles & Resources (Atom)](https://tenstorrent.github.io/tt-awesome/feeds/articles.xml)** — "
+        "articles, papers, lessons, talks, and demos.",
+        "- **[Recent Releases (Atom)](https://tenstorrent.github.io/tt-awesome/feeds/releases.xml)** — "
+        "latest stable releases. Release items use LLM-generated summaries when available.",
+        "- **[JSON Feed](https://tenstorrent.github.io/tt-awesome/feeds/feed.json)** — "
+        "combined releases, entries, and articles (JSON Feed 1.1).",
+        "- **[data.json](https://tenstorrent.github.io/tt-awesome/data.json)** — "
+        "full machine-readable entry database.",
+        "- **[llms.txt](https://tenstorrent.github.io/tt-awesome/llms.txt)** — "
+        "curated plain-text index for LLM context and AI tooling.", "",
+        "Each Atom and JSON Feed item carries both a short `<summary>` and a full rich `<content>` block "
+        "containing the project description, all associated links, attribution, and tags — "
+        "suitable for feed readers that render HTML content.", "",
+    ]
+
     # Contributing section
     lines += [
         "## Contributing", "",

--- a/scripts/summarize_releases.py
+++ b/scripts/summarize_releases.py
@@ -288,6 +288,10 @@ SYSTEM_PROMPT = (
     "changed and why it matters. Do not repeat the version number or project name. "
     "Do not use hype words like \"exciting\" or \"powerful\". Do not use bullet points."
 )
+# NOTE: the single-paragraph constraint above matters downstream — the release
+# Atom feed renders this text as a one-line <summary> (see src/feeds/releases.njk,
+# which also defensively collapses newlines via the `singleLine` filter). The
+# full text appears with paragraph breaks in the feed's <content> block.
 
 
 def call_summarization_model(repo: str, release_name: str, body: str, affiliation: str) -> str:

--- a/src/_data/recentReleases.js
+++ b/src/_data/recentReleases.js
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
 
-const fs = require("fs");
-const path = require("path");
-
 /**
  * Eleventy data file: recentReleases
  *
@@ -30,18 +27,6 @@ const path = require("path");
  * entries.js) are included — pre-release-only and unreleased entries are
  * intentionally excluded.
  */
-
-// Load planet_feeds.json (the source of LLM-generated release summaries).
-// Returns [] when absent (first build before the nightly summarize job runs).
-function loadPlanetFeeds() {
-  const p = path.join(__dirname, "planet_feeds.json");
-  if (!fs.existsSync(p)) return [];
-  try {
-    return JSON.parse(fs.readFileSync(p, "utf8"));
-  } catch (_) {
-    return [];
-  }
-}
 
 // Resolve a human-quality summary for a release. Prefers the LLM-generated
 // description from planet_feeds.json (matched by exact release URL, then by
@@ -89,7 +74,10 @@ module.exports = function () {
     });
   }
 
-  const planetFeeds = loadPlanetFeeds();
+  // Reuse the planetFeeds loader so malformed planet_feeds.json fails the build
+  // with a clear error (its contract: [] when absent, throw when malformed) —
+  // rather than silently downgrading every release summary to the fallback.
+  const planetFeeds = require("./planetFeeds")();
   for (const rel of releases) {
     rel.summary = resolveReleaseSummary(rel, planetFeeds);
     // Conform to the feedContentHtml contract (see .eleventy.js Task 1):

--- a/src/_data/recentReleases.js
+++ b/src/_data/recentReleases.js
@@ -20,6 +20,10 @@ const path = require("path");
  *     publishedAt: string   — ISO 8601 date string
  *     url:         string   — link to the GitHub release page
  *     repoUrl:     string   — link to the GitHub repo root
+ *     summary:     string   — human-quality release summary (LLM or fallback)
+ *     description: string   — same as summary; satisfies feedContentHtml contract
+ *     added_at:    string   — YYYY-MM-DD publish date
+ *     links:       array    — [{type,url,label}] repo + release links
  *   }
  *
  * Note: only entries that have a `latestStableRelease` (pre-computed in

--- a/src/_data/recentReleases.js
+++ b/src/_data/recentReleases.js
@@ -38,15 +38,19 @@ function resolveReleaseSummary(rel, planetFeeds) {
     if (item.type !== "release" || !item.description) continue;
     if (item.url === rel.url) return item.description;
   }
-  // 2. Same-repo release whose URL carries the same tag (handles html_url vs
-  //    tag-url shape differences between GitHub's API and the summarizer).
+  // 2. Same-repo release whose URL's final path segment is exactly this tag
+  //    (handles html_url vs tag-url shape differences between GitHub's API and
+  //    the summarizer). Match the tag as the trailing segment, NOT a substring:
+  //    a substring match would let tag "0.20.25" wrongly match a ".../0.20.25rc1"
+  //    release URL when both exist for the same repo.
   if (rel.repoUrl && rel.tagName) {
     const prefix = rel.repoUrl + "/releases/";
     for (const item of feeds) {
       if (item.type !== "release" || !item.description || !item.url) continue;
-      if (item.url.startsWith(prefix) && item.url.includes(rel.tagName)) {
-        return item.description;
-      }
+      if (!item.url.startsWith(prefix)) continue;
+      const norm = item.url.replace(/[?#].*$/, "").replace(/\/+$/, "");
+      const lastSegment = norm.slice(norm.lastIndexOf("/") + 1);
+      if (lastSegment === rel.tagName) return item.description;
     }
   }
   // 3. Fallback one-liner.

--- a/src/_data/recentReleases.js
+++ b/src/_data/recentReleases.js
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
 
+const fs = require("fs");
+const path = require("path");
+
 /**
  * Eleventy data file: recentReleases
  *
@@ -24,6 +27,44 @@
  * intentionally excluded.
  */
 
+// Load planet_feeds.json (the source of LLM-generated release summaries).
+// Returns [] when absent (first build before the nightly summarize job runs).
+function loadPlanetFeeds() {
+  const p = path.join(__dirname, "planet_feeds.json");
+  if (!fs.existsSync(p)) return [];
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch (_) {
+    return [];
+  }
+}
+
+// Resolve a human-quality summary for a release. Prefers the LLM-generated
+// description from planet_feeds.json (matched by exact release URL, then by
+// same-repo /releases/ path + tag name), falling back to a terse one-liner.
+function resolveReleaseSummary(rel, planetFeeds) {
+  const feeds = planetFeeds || [];
+  // 1. Exact URL match.
+  for (const item of feeds) {
+    if (item.type !== "release" || !item.description) continue;
+    if (item.url === rel.url) return item.description;
+  }
+  // 2. Same-repo release whose URL carries the same tag (handles html_url vs
+  //    tag-url shape differences between GitHub's API and the summarizer).
+  if (rel.repoUrl && rel.tagName) {
+    const prefix = rel.repoUrl + "/releases/";
+    for (const item of feeds) {
+      if (item.type !== "release" || !item.description || !item.url) continue;
+      if (item.url.startsWith(prefix) && item.url.includes(rel.tagName)) {
+        return item.description;
+      }
+    }
+  }
+  // 3. Fallback one-liner.
+  return `${rel.entryName} released ${rel.tagName}.` +
+    (rel.repoUrl ? ` Repository: ${rel.repoUrl}` : "");
+}
+
 module.exports = function () {
   const allEntries = require("./entries")();
 
@@ -44,9 +85,23 @@ module.exports = function () {
     });
   }
 
+  const planetFeeds = loadPlanetFeeds();
+  for (const rel of releases) {
+    rel.summary = resolveReleaseSummary(rel, planetFeeds);
+    // Conform to the feedContentHtml contract (see .eleventy.js Task 1):
+    rel.description = rel.summary;
+    rel.added_at = rel.publishedAt ? rel.publishedAt.slice(0, 10) : "";
+    rel.links = [
+      rel.repoUrl ? { type: "repo", url: rel.repoUrl, label: "Repository" } : null,
+      rel.url ? { type: "release", url: rel.url, label: rel.tagName } : null,
+    ].filter(Boolean);
+  }
+
   // Sort newest-first by release publish date
   releases.sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
 
   // Cap at 50 to keep page weight low; nightly fetch already limits per-repo
   return releases.slice(0, 50);
 };
+
+module.exports.resolveReleaseSummary = resolveReleaseSummary;

--- a/src/feeds/articles.njk
+++ b/src/feeds/articles.njk
@@ -21,6 +21,7 @@ eleventyExcludeFromCollections: true
     {#- type="html" + CDATA so inline markdown (e.g. `code`, **bold**) renders in
         readers without double-escaping markdown-it's already-entity-encoded output. #}
     <summary type="html"><![CDATA[{{ item.entryDesc | markdownInline | cdataSafe | safe }}]]></summary>
+    <content type="html"><![CDATA[{{ item | feedContentHtml | cdataSafe | safe }}]]></content>
     <category term="{{ item.linkType }}"/>
     <category term="{{ item.affiliation }}"/>
     {%- for cat in item.categories %}

--- a/src/feeds/articles.njk
+++ b/src/feeds/articles.njk
@@ -11,13 +11,15 @@ eleventyExcludeFromCollections: true
   <link href="https://tenstorrent.github.io/tt-awesome/"/>
   <id>https://tenstorrent.github.io/tt-awesome/feeds/articles.xml</id>
   <author><name>Tenstorrent Community</name><uri>https://tenstorrent.github.io/tt-awesome/</uri></author>
-  <updated>{{ items[0].added_at + "T00:00:00Z" if (items.length and items[0].added_at and items[0].added_at != "1970-01-01") else "1970-01-01T00:00:00Z" }}</updated>
+  <updated>{{ items[0].added_at | feedDateTime(0) if (items.length and items[0].added_at and items[0].added_at != "1970-01-01") else "1970-01-01T00:00:00Z" }}</updated>
   {%- for item in items %}
   <entry>
     <id>{{ item.linkUrl }}</id>
     <title>{{ item.entryName }} — {{ item.linkLabel }}</title>
     <link href="{{ item.linkUrl }}"/>
-    <updated>{{ item.added_at + "T00:00:00Z" }}</updated>
+    {#- date-only added_at → deterministic descending time by feed position so
+        same-day items keep a stable order in date-sorting readers. #}
+    <updated>{{ item.added_at | feedDateTime(loop.index0) }}</updated>
     {#- type="html" + CDATA so inline markdown (e.g. `code`, **bold**) renders in
         readers without double-escaping markdown-it's already-entity-encoded output. #}
     <summary type="html"><![CDATA[{{ item.entryDesc | markdownInline | cdataSafe | safe }}]]></summary>

--- a/src/feeds/new-entries.njk
+++ b/src/feeds/new-entries.njk
@@ -14,7 +14,7 @@ eleventyExcludeFromCollections: true
   <updated>{{ sortedEntries[0].added_at | feedDateTime(0) if (sortedEntries.length and sortedEntries[0].added_at) else "1970-01-01T00:00:00Z" }}</updated>
   {%- for entry in sortedEntries %}
   {%- if loop.index <= 50 %}
-  {%- set repoLink = entry.links | selectattr("type", "equalto", "repo") | first %}
+  {%- set repoLink = entry.links | firstLinkOfType("repo") %}
   <entry>
     <id>{{ repoLink.url if repoLink else "https://tenstorrent.github.io/tt-awesome/#" + entry.id }}</id>
     <title>{{ entry.name }}</title>

--- a/src/feeds/new-entries.njk
+++ b/src/feeds/new-entries.njk
@@ -23,6 +23,9 @@ eleventyExcludeFromCollections: true
     {#- type="html" + CDATA so inline markdown renders in readers without
         double-escaping markdown-it's already-entity-encoded output. #}
     <summary type="html"><![CDATA[{{ entry.description | markdownInline | cdataSafe | safe }}]]></summary>
+    {#- Full rich content block for feed readers; summary above stays a clean
+        one-liner so Slack's RSS app (which flattens HTML) still reads well. #}
+    <content type="html"><![CDATA[{{ entry | feedContentHtml | cdataSafe | safe }}]]></content>
     <category term="{{ entry.affiliation }}"/>
     {%- for cat in entry.categories %}
     <category term="{{ cat }}"/>

--- a/src/feeds/new-entries.njk
+++ b/src/feeds/new-entries.njk
@@ -11,7 +11,7 @@ eleventyExcludeFromCollections: true
   <id>https://tenstorrent.github.io/tt-awesome/feeds/new-entries.xml</id>
   <author><name>Tenstorrent Community</name><uri>https://tenstorrent.github.io/tt-awesome/</uri></author>
   {%- set sortedEntries = entries | sort(true, false, "added_at") %}
-  <updated>{{ sortedEntries[0].added_at + "T00:00:00Z" if (sortedEntries.length and sortedEntries[0].added_at) else "1970-01-01T00:00:00Z" }}</updated>
+  <updated>{{ sortedEntries[0].added_at | feedDateTime(0) if (sortedEntries.length and sortedEntries[0].added_at) else "1970-01-01T00:00:00Z" }}</updated>
   {%- for entry in sortedEntries %}
   {%- if loop.index <= 50 %}
   {%- set repoLink = entry.links | selectattr("type", "equalto", "repo") | first %}
@@ -19,7 +19,10 @@ eleventyExcludeFromCollections: true
     <id>{{ repoLink.url if repoLink else "https://tenstorrent.github.io/tt-awesome/#" + entry.id }}</id>
     <title>{{ entry.name }}</title>
     <link href="{{ repoLink.url if repoLink else "https://tenstorrent.github.io/tt-awesome/#" + entry.id }}"/>
-    <updated>{{ entry.added_at + "T00:00:00Z" if entry.added_at else "1970-01-01T00:00:00Z" }}</updated>
+    {#- added_at is date-only; feedDateTime synthesizes a deterministic
+        descending time from feed position so same-day entries keep a stable
+        order in date-sorting readers. #}
+    <updated>{{ entry.added_at | feedDateTime(loop.index0) if entry.added_at else "1970-01-01T00:00:00Z" }}</updated>
     {#- type="html" + CDATA so inline markdown renders in readers without
         double-escaping markdown-it's already-entity-encoded output. #}
     <summary type="html"><![CDATA[{{ entry.description | markdownInline | cdataSafe | safe }}]]></summary>

--- a/src/feeds/releases.njk
+++ b/src/feeds/releases.njk
@@ -19,7 +19,9 @@ eleventyExcludeFromCollections: true
     <title>{{ rel.entryName }} {{ rel.tagName }}</title>
     <link href="{{ rel.url }}"/>
     <updated>{{ rel.publishedAt }}</updated>
-    <summary type="html"><![CDATA[{{ rel.summary | markdownInline | cdataSafe | safe }}]]></summary>
+    {#- singleLine collapses any newlines so the summary is always one clean
+        line (the full multi-paragraph text still appears in <content>). #}
+    <summary type="html"><![CDATA[{{ rel.summary | singleLine | markdownInline | cdataSafe | safe }}]]></summary>
     <content type="html"><![CDATA[{{ rel | feedContentHtml | cdataSafe | safe }}]]></content>
     <category term="{{ rel.affiliation }}"/>
     <category term="release"/>

--- a/src/feeds/releases.njk
+++ b/src/feeds/releases.njk
@@ -19,7 +19,8 @@ eleventyExcludeFromCollections: true
     <title>{{ rel.entryName }} {{ rel.tagName }}</title>
     <link href="{{ rel.url }}"/>
     <updated>{{ rel.publishedAt }}</updated>
-    <summary>{{ rel.entryName }} released {{ rel.tagName }}. Repository: {{ rel.repoUrl }}</summary>
+    <summary type="html"><![CDATA[{{ rel.summary | markdownInline | cdataSafe | safe }}]]></summary>
+    <content type="html"><![CDATA[{{ rel | feedContentHtml | cdataSafe | safe }}]]></content>
     <category term="{{ rel.affiliation }}"/>
     <category term="release"/>
   </entry>

--- a/src/llms-txt.njk
+++ b/src/llms-txt.njk
@@ -1,0 +1,22 @@
+---
+permalink: /llms.txt
+eleventyExcludeFromCollections: true
+---
+# tt-awesome
+
+> A curated directory of projects, tools, models, and research for Tenstorrent hardware — contributed by the community and the Tenstorrent team. Generated from the entries in this repository.
+
+## Feeds & Data
+
+- [JSON Feed](https://tenstorrent.github.io/tt-awesome/feeds/feed.json): combined releases, entries, and articles (JSON Feed 1.1).
+- [New Entries (Atom)](https://tenstorrent.github.io/tt-awesome/feeds/new-entries.xml): newly added projects and resources.
+- [Articles & Resources (Atom)](https://tenstorrent.github.io/tt-awesome/feeds/articles.xml): articles, papers, lessons, talks, videos, demos.
+- [Recent Releases (Atom)](https://tenstorrent.github.io/tt-awesome/feeds/releases.xml): latest stable releases.
+- [data.json](https://tenstorrent.github.io/tt-awesome/data.json): the full machine-readable entry database.
+- [README](https://github.com/tenstorrent/tt-awesome/blob/main/README.md): human-readable directory.
+{% for cat in categories %}
+## {{ cat.label | safe }}
+{% for entry in entries | sort(false, false, "name") %}{% if entry.categories and (cat.slug in entry.categories) %}{%- set repoLink = entry.links | selectattr("type", "equalto", "repo") | first %}{%- set anyLink = entry.links | first %}
+- [{{ entry.name | safe }}]({{ repoLink.url if repoLink else (anyLink.url if anyLink else "https://tenstorrent.github.io/tt-awesome/#" + entry.id) }}): {{ entry.description | striptags | replace("\n", " ") | safe }}
+{%- endif %}{% endfor %}
+{% endfor %}

--- a/src/llms-txt.njk
+++ b/src/llms-txt.njk
@@ -16,7 +16,7 @@ eleventyExcludeFromCollections: true
 - [README](https://github.com/tenstorrent/tt-awesome/blob/main/README.md): human-readable directory.
 {% for cat in categories %}
 ## {{ cat.label | safe }}
-{% for entry in entries | sort(false, false, "name") %}{% if entry.categories and (cat.slug in entry.categories) %}{%- set repoLink = entry.links | selectattr("type", "equalto", "repo") | first %}{%- set anyLink = entry.links | first %}
+{% for entry in entries | sort(false, false, "name") %}{% if entry.categories and (cat.slug in entry.categories) %}{%- set repoLink = entry.links | firstLinkOfType("repo") %}{%- set anyLink = entry.links | first %}
 - [{{ entry.name | safe }}]({{ repoLink.url if repoLink else (anyLink.url if anyLink else "https://tenstorrent.github.io/tt-awesome/#" + entry.id) }}): {{ entry.description | striptags | replace("\n", " ") | safe }}
 {%- endif %}{% endfor %}
 {% endfor %}

--- a/tests/test_eleventy_filters.js
+++ b/tests/test_eleventy_filters.js
@@ -433,4 +433,62 @@ assert(typeof cdataSafe === "function", "cdataSafe filter not registered");
   console.log("✓ cdataSafe: neutralizes ]]> sequences");
 }
 
+// ── feedContentHtml tests ────────────────────────────────────────────────────
+const feedContentHtml = filters["feedContentHtml"];
+assert(typeof feedContentHtml === "function", "feedContentHtml filter not registered");
+{
+  const html = feedContentHtml({
+    description: "Boltz-2 on **Blackhole**.",
+    links: [
+      { type: "repo", url: "https://github.com/test/repo", label: "GitHub" },
+      { type: "article", url: "https://example.com/post" },
+    ],
+    author: "moritztng",
+    author_url: "https://github.com/moritztng",
+    affiliation: "community",
+    tags: ["blackhole", "drug-discovery"],
+    categories: ["ai-models"],
+    added_at: "2026-05-13",
+  });
+  // description rendered as block markdown
+  assert.ok(html.includes("<strong>Blackhole</strong>"), "renders markdown emphasis");
+  // links list with both links; missing label falls back to title-cased type
+  assert.ok(html.includes('<a href="https://github.com/test/repo">GitHub</a>'), "labeled link");
+  assert.ok(html.includes('<a href="https://example.com/post">Article</a>'), "fallback label is title-cased type");
+  // attribution: linked author handle, affiliation, added date
+  assert.ok(html.includes('<a href="https://github.com/moritztng">@moritztng</a>'), "linked author handle");
+  assert.ok(html.includes("community"), "affiliation present");
+  assert.ok(html.includes("2026-05-13"), "added date present");
+  // tags + categories
+  assert.ok(html.includes("blackhole") && html.includes("ai-models"), "tags + categories present");
+  console.log("✓ feedContentHtml: renders description, links, attribution, tags");
+}
+{
+  // Missing sections are omitted, not rendered empty.
+  const html = feedContentHtml({ description: "Just a description." });
+  assert.ok(html.includes("Just a description."), "description present");
+  assert.ok(!html.includes("<ul>"), "no links list when no links");
+  assert.ok(!html.includes("Links:"), "no Links heading when no links");
+  console.log("✓ feedContentHtml: omits absent sections");
+}
+{
+  // Escapes HTML in text fields and never emits an <img>.
+  const html = feedContentHtml({
+    description: "![x](http://evil/pixel.gif)",
+    author: "a<b>c",
+    links: [{ type: "repo", url: "https://x/y", label: "<script>" }],
+    tags: ["t&g"],
+  });
+  assert.ok(!html.includes("<img"), "no img from image markdown");
+  assert.ok(!html.includes("<script>"), "label HTML escaped");
+  assert.ok(html.includes("a&lt;b&gt;c"), "author HTML escaped");
+  assert.ok(html.includes("t&amp;g"), "tag ampersand escaped");
+  console.log("✓ feedContentHtml: escapes text fields, blocks images");
+}
+{
+  assert.strictEqual(feedContentHtml(null), "", "null input → empty string");
+  assert.strictEqual(feedContentHtml(undefined), "", "undefined input → empty string");
+  console.log("✓ feedContentHtml: empty input safe");
+}
+
 console.log("\nAll eleventy filter tests passed ✓");

--- a/tests/test_eleventy_filters.js
+++ b/tests/test_eleventy_filters.js
@@ -167,6 +167,18 @@ function makeRelease(overrides) {
   console.log("✓ jsonFeedItems: release items use rel.summary");
 }
 
+// Test 8c: release with no rel.summary falls back to the one-liner string.
+{
+  const rel = makeRelease(); // no summary field
+  const items = jsonFeedItems([], [rel]);
+  assert.strictEqual(
+    items[0].summary,
+    "Test Entry released v1.0.0. Repository: https://github.com/test/repo",
+    "release summary falls back to one-liner when rel.summary absent"
+  );
+  console.log("✓ jsonFeedItems: release summary falls back to one-liner");
+}
+
 // Test 9: entry items appear with correct shape
 {
   const entry = makeEntry({ links: [{ type: "repo", url: "https://github.com/test/repo" }] });
@@ -180,7 +192,7 @@ function makeRelease(overrides) {
 }
 
 // Test 9b: items carry content_html (JSON Feed 1.1 requires content_html or
-// content_text) with inline markdown rendered; summary stays plain text.
+// content_text) — now a rich block with inline markdown rendered inside it; summary stays plain text.
 {
   const entry = makeEntry({
     description: "Uses `tt_metal` under the hood.",

--- a/tests/test_eleventy_filters.js
+++ b/tests/test_eleventy_filters.js
@@ -241,6 +241,25 @@ function makeRelease(overrides) {
   console.log("✓ jsonFeedItems: article link items produced");
 }
 
+// Test 11b: an article-link item's content lists ONLY its own link, not the
+// entry's whole link set (the entry item already carries all links). Avoids
+// byte-identical duplicate content across the two items.
+{
+  const entry = makeEntry(); // has a repo link + an article link
+  const items = jsonFeedItems([entry], []);
+  const entryItem   = items.find((i) => i.tags.includes("entry"));
+  const articleItem = items.find((i) => i.tags.includes("article"));
+  assert.ok(entryItem.content_html.includes("https://github.com/test/repo"),
+    "entry item content includes the repo link");
+  assert.ok(!articleItem.content_html.includes("https://github.com/test/repo"),
+    "article item content omits the repo link (focuses on its own link)");
+  assert.ok(articleItem.content_html.includes("https://example.com/article"),
+    "article item content includes its own link");
+  assert.notStrictEqual(entryItem.content_html, articleItem.content_html,
+    "entry and article item content are not byte-identical");
+  console.log("✓ jsonFeedItems: article item content focuses on its own link");
+}
+
 // Test 12: output is sorted newest-first by date_published
 {
   const oldRel = makeRelease({ publishedAt: "2025-01-01T00:00:00Z", url: "https://github.com/test/repo/releases/tag/v0.1" });
@@ -550,6 +569,63 @@ assert(typeof feedContentHtml === "function", "feedContentHtml filter not regist
   assert.ok(!html.includes("javascript:"), "javascript: scheme dropped");
   assert.ok(html.includes("https://github.com/ok/repo"), "https link kept");
   console.log("✓ feedContentHtml: drops non-http(s) link schemes");
+}
+{
+  // Links render inline with " · ", NOT as a <ul>/<li> list, so they stay
+  // readable when a client flattens the HTML to plain text (Slack RSS).
+  const html = feedContentHtml({
+    description: "x",
+    links: [
+      { type: "repo", url: "https://github.com/a/b", label: "Repo" },
+      { type: "release", url: "https://github.com/a/b/releases/tag/1.3.0", label: "1.3.0" },
+    ],
+  });
+  assert.ok(!html.includes("<ul>") && !html.includes("<li>"), "no list markup");
+  assert.ok(html.includes("</a> · <a"), "links joined by middot separator");
+  assert.ok(html.includes("<strong>Links:</strong> <a"), "inline Links label");
+  console.log("✓ feedContentHtml: links render inline with separator");
+}
+{
+  // Attribution: '@handle' only when author_url is a github.com profile.
+  const gh = feedContentHtml({ author: "geohot", author_url: "https://github.com/geohot" });
+  assert.ok(gh.includes('By <a href="https://github.com/geohot">@geohot</a>'), "github author → @handle linked");
+
+  // A display name / author list with NO url → plain "By Name", no '@'.
+  const name = feedContentHtml({ author: "Jenny Lynn Almerol, Mario Spera" });
+  assert.ok(name.includes("By Jenny Lynn Almerol, Mario Spera"), "plain name rendered");
+  assert.ok(!name.includes("@"), "no bogus @ prefix on a non-handle author");
+
+  // A non-github profile url → linked name without '@'.
+  const other = feedContentHtml({ author: "Martin Chang", author_url: "https://example.com/martin" });
+  assert.ok(other.includes('By <a href="https://example.com/martin">Martin Chang</a>'), "non-github url → linked name");
+  assert.ok(!other.includes("@"), "no @ for non-github profile");
+  console.log("✓ feedContentHtml: @handle only for github.com authors");
+}
+// ── feedDateTime tests ───────────────────────────────────────────────────────
+const feedDateTime = filters["feedDateTime"];
+assert(typeof feedDateTime === "function", "feedDateTime filter not registered");
+{
+  // Date-only input gets a synthesized descending time keyed to feed index, so
+  // earlier (newer) items sort above later ones on the same day.
+  const newer = feedDateTime("2026-05-08", 0);
+  const older = feedDateTime("2026-05-08", 5);
+  assert.strictEqual(newer, "2026-05-08T23:59:59Z", "index 0 → end of day");
+  assert.strictEqual(older, "2026-05-08T23:59:54Z", "index 5 → 5s earlier");
+  assert.ok(newer > older, "earlier feed index sorts later in time (newest-first preserved)");
+  // A value that already carries a time passes through untouched.
+  assert.strictEqual(feedDateTime("2026-06-29T07:46:11Z", 3), "2026-06-29T07:46:11Z", "full timestamp passthrough");
+  // Empty input is safe.
+  assert.strictEqual(feedDateTime("", 0), "1970-01-01T00:00:00Z", "empty → epoch");
+  console.log("✓ feedDateTime: deterministic intra-day ordering + passthrough");
+}
+// ── singleLine tests ─────────────────────────────────────────────────────────
+const singleLine = filters["singleLine"];
+assert(typeof singleLine === "function", "singleLine filter not registered");
+{
+  assert.strictEqual(singleLine("a\n\nb\n  c"), "a b c", "collapses newlines and runs of whitespace");
+  assert.strictEqual(singleLine("  trim me  "), "trim me", "trims ends");
+  assert.strictEqual(singleLine(undefined), "", "undefined → empty");
+  console.log("✓ singleLine: collapses whitespace to a single line");
 }
 
 console.log("\nAll eleventy filter tests passed ✓");

--- a/tests/test_eleventy_filters.js
+++ b/tests/test_eleventy_filters.js
@@ -54,7 +54,7 @@ function makeEntry(overrides) {
 }
 
 function makeRelease(overrides) {
-  return {
+  const base = {
     entryId:     "test-entry",
     entryName:   "Test Entry",
     affiliation: "official",
@@ -64,6 +64,9 @@ function makeRelease(overrides) {
     repoUrl:     "https://github.com/test/repo",
     ...overrides,
   };
+  // Conform to feedContentHtml contract: description = summary
+  if (!base.description && base.summary) base.description = base.summary;
+  return base;
 }
 
 // ── articleFeedItems tests ────────────────────────────────────────────────────
@@ -153,6 +156,17 @@ function makeRelease(overrides) {
   console.log("✓ jsonFeedItems: release items have correct shape");
 }
 
+// Test 8b: release items use rel.summary as their summary text.
+{
+  const rel = makeRelease({ summary: "Rich release summary here." });
+  const items = jsonFeedItems([], [rel]);
+  assert.strictEqual(items[0].summary, "Rich release summary here.",
+    "release summary comes from rel.summary");
+  assert.ok(items[0].content_html.includes("Rich release summary here."),
+    "release content_html renders the summary");
+  console.log("✓ jsonFeedItems: release items use rel.summary");
+}
+
 // Test 9: entry items appear with correct shape
 {
   const entry = makeEntry({ links: [{ type: "repo", url: "https://github.com/test/repo" }] });
@@ -174,8 +188,9 @@ function makeRelease(overrides) {
   });
   const items = jsonFeedItems([entry], []);
   const entryItem = items.find((i) => i.tags.includes("entry"));
-  assert.strictEqual(entryItem.content_html, "Uses <code>tt_metal</code> under the hood.",
-    "content_html renders inline markdown");
+  // content_html is now the rich block — it CONTAINS the rendered description.
+  assert.ok(entryItem.content_html.includes("<code>tt_metal</code>"),
+    "content_html renders the description as markdown");
   assert.strictEqual(entryItem.summary, "Uses `tt_metal` under the hood.",
     "summary stays plain text");
   assert.ok(items.every((i) => typeof i.content_html === "string"),

--- a/tests/test_eleventy_filters.js
+++ b/tests/test_eleventy_filters.js
@@ -140,9 +140,30 @@ function makeRelease(overrides) {
   console.log("✓ articleFeedItems: missing added_at falls back to 1970-01-01");
 }
 
+// Test 8: articleFeedItems carries fields needed by feedContentHtml.
+{
+  const entry = makeEntry({
+    author: "alice",
+    author_url: "https://github.com/alice",
+    tags: ["blackhole"],
+    links: [
+      { type: "repo", url: "https://github.com/test/repo" },
+      { type: "article", url: "https://example.com/article", label: "Read more" },
+    ],
+  });
+  const items = articleFeedItems([entry], 50);
+  const it = items[0];
+  assert.strictEqual(it.description, "A test entry.", "carries entry description");
+  assert.strictEqual(it.author, "alice", "carries author");
+  assert.strictEqual(it.author_url, "https://github.com/alice", "carries author_url");
+  assert.deepStrictEqual(it.tags, ["blackhole"], "carries tags");
+  assert.strictEqual(it.links.length, 2, "carries entry's full links array");
+  console.log("✓ articleFeedItems: carries feedContentHtml contract fields");
+}
+
 // ── jsonFeedItems tests ───────────────────────────────────────────────────────
 
-// Test 8: release items appear with correct shape
+// Test 9: release items appear with correct shape
 {
   const rel = makeRelease();
   const items = jsonFeedItems([], [rel]);
@@ -156,7 +177,7 @@ function makeRelease(overrides) {
   console.log("✓ jsonFeedItems: release items have correct shape");
 }
 
-// Test 8b: release items use rel.summary as their summary text.
+// Test 9b: release items use rel.summary as their summary text.
 {
   const rel = makeRelease({ summary: "Rich release summary here." });
   const items = jsonFeedItems([], [rel]);
@@ -167,7 +188,7 @@ function makeRelease(overrides) {
   console.log("✓ jsonFeedItems: release items use rel.summary");
 }
 
-// Test 8c: release with no rel.summary falls back to the one-liner string.
+// Test 9c: release with no rel.summary falls back to the one-liner string.
 {
   const rel = makeRelease(); // no summary field
   const items = jsonFeedItems([], [rel]);
@@ -179,7 +200,7 @@ function makeRelease(overrides) {
   console.log("✓ jsonFeedItems: release summary falls back to one-liner");
 }
 
-// Test 9: entry items appear with correct shape
+// Test 10: entry items appear with correct shape
 {
   const entry = makeEntry({ links: [{ type: "repo", url: "https://github.com/test/repo" }] });
   const items = jsonFeedItems([entry], []);
@@ -191,7 +212,7 @@ function makeRelease(overrides) {
   console.log("✓ jsonFeedItems: entry items have correct shape");
 }
 
-// Test 9b: items carry content_html (JSON Feed 1.1 requires content_html or
+// Test 10b: items carry content_html (JSON Feed 1.1 requires content_html or
 // content_text) — now a rich block with inline markdown rendered inside it; summary stays plain text.
 {
   const entry = makeEntry({
@@ -210,7 +231,7 @@ function makeRelease(overrides) {
   console.log("✓ jsonFeedItems: items carry rendered content_html + plain summary");
 }
 
-// Test 10: article-type links produce article items
+// Test 11: article-type links produce article items
 {
   const entry = makeEntry();
   const items = jsonFeedItems([entry], []);
@@ -220,7 +241,7 @@ function makeRelease(overrides) {
   console.log("✓ jsonFeedItems: article link items produced");
 }
 
-// Test 11: output is sorted newest-first by date_published
+// Test 12: output is sorted newest-first by date_published
 {
   const oldRel = makeRelease({ publishedAt: "2025-01-01T00:00:00Z", url: "https://github.com/test/repo/releases/tag/v0.1" });
   const newRel = makeRelease({ publishedAt: "2026-06-01T00:00:00Z", url: "https://github.com/test/repo/releases/tag/v2.0" });
@@ -237,7 +258,7 @@ function makeRelease(overrides) {
   console.log("✓ jsonFeedItems: output sorted newest-first by date_published");
 }
 
-// Test 12: empty affiliation is filtered from tags
+// Test 13: empty affiliation is filtered from tags
 {
   const entry = makeEntry({ affiliation: "", links: [{ type: "repo", url: "https://github.com/test/repo" }] });
   const items = jsonFeedItems([entry], []);
@@ -246,7 +267,7 @@ function makeRelease(overrides) {
   console.log("✓ jsonFeedItems: empty affiliation filtered from tags");
 }
 
-// Test 13: entries without repo link fall back to first available link URL
+// Test 14: entries without repo link fall back to first available link URL
 {
   const entry = makeEntry({ links: [{ type: "article", url: "https://example.com/article" }] });
   const items = jsonFeedItems([entry], []);
@@ -256,7 +277,7 @@ function makeRelease(overrides) {
   console.log("✓ jsonFeedItems: no-repo entry falls back to first available link URL");
 }
 
-// Test 14: entries with no links at all fall back to anchor URL
+// Test 15: entries with no links at all fall back to anchor URL
 {
   const entry = makeEntry({ links: [] });
   const items = jsonFeedItems([entry], []);
@@ -275,7 +296,7 @@ assert(typeof planetItems  === "function", "planetItems filter not registered");
 assert(typeof monthLabel   === "function", "monthLabel filter not registered");
 assert(typeof monthKey     === "function", "monthKey filter not registered");
 
-// Test 15: article links appear in planet items
+// Test 16: article links appear in planet items
 {
   const entry = makeEntry({ links: [
     { type: "repo",    url: "https://github.com/test/repo" },
@@ -291,7 +312,7 @@ assert(typeof monthKey     === "function", "monthKey filter not registered");
   console.log("✓ planetItems: article links included with correct shape");
 }
 
-// Test 16: releases appear with type "release"
+// Test 17: releases appear with type "release"
 {
   const rel = makeRelease();
   const items = planetItems([], [rel], []);
@@ -303,7 +324,7 @@ assert(typeof monthKey     === "function", "monthKey filter not registered");
   console.log("✓ planetItems: releases included with correct shape");
 }
 
-// Test 17: output sorted newest-first
+// Test 18: output sorted newest-first
 {
   const old  = makeEntry({ id: "old",  added_at: "2025-01-01", links: [{ type: "article", url: "https://example.com/old" }] });
   const newE = makeEntry({ id: "newE", added_at: "2026-06-01", links: [{ type: "article", url: "https://example.com/new" }] });
@@ -313,7 +334,7 @@ assert(typeof monthKey     === "function", "monthKey filter not registered");
   console.log("✓ planetItems: sorted newest-first");
 }
 
-// Test 18: deduplication by URL
+// Test 19: deduplication by URL
 {
   const e1 = makeEntry({ id: "e1", links: [{ type: "article", url: "https://example.com/same" }] });
   const e2 = makeEntry({ id: "e2", links: [{ type: "article", url: "https://example.com/same" }] });
@@ -322,7 +343,7 @@ assert(typeof monthKey     === "function", "monthKey filter not registered");
   console.log("✓ planetItems: deduplicates by URL");
 }
 
-// Test 19: all six article types included
+// Test 20: all six article types included
 {
   const types = ["article", "lesson", "paper", "talk", "video", "demo"];
   const links = types.map((t) => ({ type: t, url: `https://example.com/${t}` }));
@@ -334,7 +355,7 @@ assert(typeof monthKey     === "function", "monthKey filter not registered");
   console.log("✓ planetItems: all six article types included");
 }
 
-// Test 20: monthLabel converts correctly
+// Test 21: monthLabel converts correctly
 {
   assert.strictEqual(monthLabel("2026-05"),    "May 2026");
   assert.strictEqual(monthLabel("2026-05-01"), "May 2026");
@@ -344,7 +365,7 @@ assert(typeof monthKey     === "function", "monthKey filter not registered");
   console.log("✓ monthLabel: converts YYYY-MM and YYYY-MM-DD correctly");
 }
 
-// Test 21: monthKey slices YYYY-MM from date strings
+// Test 22: monthKey slices YYYY-MM from date strings
 {
   assert.strictEqual(monthKey("2026-05-01"), "2026-05");
   assert.strictEqual(monthKey("2026-12-31"), "2026-12");
@@ -354,14 +375,14 @@ assert(typeof monthKey     === "function", "monthKey filter not registered");
   console.log("✓ monthKey: slices YYYY-MM correctly");
 }
 
-// Test 22: monthLabel guards invalid month numbers
+// Test 23: monthLabel guards invalid month numbers
 {
   assert.strictEqual(monthLabel("2026-00-15"), "2026-00-15"); // month 0 → returns dateStr
   assert.strictEqual(monthLabel("2026-13-01"), "2026-13-01"); // month 13 → returns dateStr
   console.log("✓ monthLabel: guards out-of-range month numbers");
 }
 
-// Test 23: planetItems excludes dev releases (all known patterns)
+// Test 24: planetItems excludes dev releases (all known patterns)
 {
   const mkRel = (tagName, url) => ({
     entryId: "x", entryName: "X", affiliation: "official",
@@ -381,7 +402,7 @@ assert(typeof monthKey     === "function", "monthKey filter not registered");
   console.log("✓ planetItems: excludes .dev, -dev, and -dev.<digits> release tags");
 }
 
-// Test 24: approved external items appear
+// Test 25: approved external items appear
 {
   const extApproved1 = {
     type: "video", source: "youtube", approved: true,

--- a/tests/test_eleventy_filters.js
+++ b/tests/test_eleventy_filters.js
@@ -599,7 +599,13 @@ assert(typeof feedContentHtml === "function", "feedContentHtml filter not regist
   const other = feedContentHtml({ author: "Martin Chang", author_url: "https://example.com/martin" });
   assert.ok(other.includes('By <a href="https://example.com/martin">Martin Chang</a>'), "non-github url → linked name");
   assert.ok(!other.includes("@"), "no @ for non-github profile");
-  console.log("✓ feedContentHtml: @handle only for github.com authors");
+
+  // Defense-in-depth: a dangerous-scheme author_url must NOT become a live href.
+  const evil = feedContentHtml({ author: "x", author_url: "javascript:alert(1)" });
+  assert.ok(!evil.includes("javascript:"), "javascript: author_url dropped");
+  assert.ok(!evil.includes("<a "), "no anchor for non-http(s) author_url");
+  assert.ok(evil.includes("By x"), "author rendered as plain text");
+  console.log("✓ feedContentHtml: @handle only for github.com authors; author_url scheme-guarded");
 }
 // ── feedDateTime tests ───────────────────────────────────────────────────────
 const feedDateTime = filters["feedDateTime"];

--- a/tests/test_eleventy_filters.js
+++ b/tests/test_eleventy_filters.js
@@ -607,6 +607,21 @@ assert(typeof feedContentHtml === "function", "feedContentHtml filter not regist
   assert.ok(evil.includes("By x"), "author rendered as plain text");
   console.log("✓ feedContentHtml: @handle only for github.com authors; author_url scheme-guarded");
 }
+// ── firstLinkOfType tests ────────────────────────────────────────────────────
+const firstLinkOfType = filters["firstLinkOfType"];
+assert(typeof firstLinkOfType === "function", "firstLinkOfType filter not registered");
+{
+  const links = [
+    { type: "article", url: "https://x/a" },
+    { type: "repo", url: "https://x/repo" },
+    { type: "repo", url: "https://x/repo2" },
+  ];
+  assert.strictEqual(firstLinkOfType(links, "repo").url, "https://x/repo", "returns first matching type");
+  assert.strictEqual(firstLinkOfType(links, "video"), null, "no match → null");
+  assert.strictEqual(firstLinkOfType(undefined, "repo"), null, "missing links → null");
+  assert.strictEqual(firstLinkOfType([{}, null], "repo"), null, "skips falsy/typeless entries");
+  console.log("✓ firstLinkOfType: selects first link of a type, null otherwise");
+}
 // ── feedDateTime tests ───────────────────────────────────────────────────────
 const feedDateTime = filters["feedDateTime"];
 assert(typeof feedDateTime === "function", "feedDateTime filter not registered");

--- a/tests/test_eleventy_filters.js
+++ b/tests/test_eleventy_filters.js
@@ -490,5 +490,18 @@ assert(typeof feedContentHtml === "function", "feedContentHtml filter not regist
   assert.strictEqual(feedContentHtml(undefined), "", "undefined input → empty string");
   console.log("✓ feedContentHtml: empty input safe");
 }
+{
+  // Defense-in-depth: non-http(s) link schemes must not become live hrefs.
+  const html = feedContentHtml({
+    description: "x",
+    links: [
+      { type: "repo", url: "javascript:alert(1)", label: "evil" },
+      { type: "repo", url: "https://github.com/ok/repo", label: "ok" },
+    ],
+  });
+  assert.ok(!html.includes("javascript:"), "javascript: scheme dropped");
+  assert.ok(html.includes("https://github.com/ok/repo"), "https link kept");
+  console.log("✓ feedContentHtml: drops non-http(s) link schemes");
+}
 
 console.log("\nAll eleventy filter tests passed ✓");

--- a/tests/test_recent_releases.js
+++ b/tests/test_recent_releases.js
@@ -37,6 +37,31 @@ const rel = {
   console.log("✓ resolveReleaseSummary: same-repo + tag fallback match");
 }
 
+// Tag must match as the trailing URL segment, NOT a substring: a release whose
+// tag is a prefix of another tag (1.3.0 vs 1.3.0rc1) must not be mismatched.
+{
+  const relPrefix = {
+    entryName: "tt-forge-onnx",
+    tagName: "1.3.0",
+    repoUrl: "https://github.com/tenstorrent/tt-forge-onnx",
+    url: "https://github.com/tenstorrent/tt-forge-onnx/releases/tag/1.3.0",
+  };
+  // Only a pre-release whose tag *contains* "1.3.0" is present — must NOT match.
+  const feeds = [
+    {
+      type: "release",
+      url: "https://github.com/tenstorrent/tt-forge-onnx/releases/tag/1.3.0rc1",
+      description: "Pre-release summary — should NOT be used for 1.3.0.",
+    },
+  ];
+  assert.strictEqual(
+    resolveReleaseSummary(relPrefix, feeds),
+    "tt-forge-onnx released 1.3.0. Repository: https://github.com/tenstorrent/tt-forge-onnx",
+    "prefix tag collision falls through to the one-liner, not the rc summary"
+  );
+  console.log("✓ resolveReleaseSummary: tag matched as trailing segment, not substring");
+}
+
 // No match → fallback string.
 {
   const feeds = [

--- a/tests/test_recent_releases.js
+++ b/tests/test_recent_releases.js
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 Tenstorrent USA, Inc.
+
+// Tests for resolveReleaseSummary in src/_data/recentReleases.js.
+// Run with: node tests/test_recent_releases.js
+const assert = require("assert");
+const { resolveReleaseSummary } = require("../src/_data/recentReleases.js");
+
+assert(typeof resolveReleaseSummary === "function", "resolveReleaseSummary not exported");
+
+const rel = {
+  entryName: "tt-forge-onnx",
+  tagName: "1.3.0",
+  repoUrl: "https://github.com/tenstorrent/tt-forge-onnx",
+  url: "https://github.com/tenstorrent/tt-forge-onnx/releases/tag/1.3.0",
+};
+
+// Exact URL match → rich description.
+{
+  const feeds = [
+    { type: "release", url: rel.url, description: "Rich synchronized-updates summary." },
+  ];
+  assert.strictEqual(resolveReleaseSummary(rel, feeds), "Rich synchronized-updates summary.");
+  console.log("✓ resolveReleaseSummary: exact URL match returns rich description");
+}
+
+// Same-repo /releases/ + tag match (URLs differ slightly) → rich description.
+{
+  const feeds = [
+    {
+      type: "release",
+      url: "https://github.com/tenstorrent/tt-forge-onnx/releases/1.3.0",
+      description: "Fuzzy-matched summary.",
+    },
+  ];
+  assert.strictEqual(resolveReleaseSummary(rel, feeds), "Fuzzy-matched summary.");
+  console.log("✓ resolveReleaseSummary: same-repo + tag fallback match");
+}
+
+// No match → fallback string.
+{
+  const feeds = [
+    { type: "release", url: "https://github.com/other/repo/releases/tag/9.9.9", description: "Unrelated." },
+  ];
+  assert.strictEqual(
+    resolveReleaseSummary(rel, feeds),
+    "tt-forge-onnx released 1.3.0. Repository: https://github.com/tenstorrent/tt-forge-onnx"
+  );
+  console.log("✓ resolveReleaseSummary: no match returns fallback string");
+}
+
+// Missing/empty feeds → fallback (does not throw).
+{
+  assert.strictEqual(
+    resolveReleaseSummary(rel, []),
+    "tt-forge-onnx released 1.3.0. Repository: https://github.com/tenstorrent/tt-forge-onnx"
+  );
+  assert.strictEqual(
+    resolveReleaseSummary(rel, undefined),
+    "tt-forge-onnx released 1.3.0. Repository: https://github.com/tenstorrent/tt-forge-onnx"
+  );
+  console.log("✓ resolveReleaseSummary: empty/undefined feeds safe");
+}
+
+// Non-release feed items are ignored.
+{
+  const feeds = [{ type: "article", url: rel.url, description: "Should be ignored." }];
+  assert.ok(resolveReleaseSummary(rel, feeds).startsWith("tt-forge-onnx released"),
+    "non-release items ignored");
+  console.log("✓ resolveReleaseSummary: ignores non-release feed items");
+}
+
+console.log("\nAll recentReleases tests passed ✓");

--- a/tests/test_recent_releases.js
+++ b/tests/test_recent_releases.js
@@ -65,8 +65,11 @@ const rel = {
 // Non-release feed items are ignored.
 {
   const feeds = [{ type: "article", url: rel.url, description: "Should be ignored." }];
-  assert.ok(resolveReleaseSummary(rel, feeds).startsWith("tt-forge-onnx released"),
-    "non-release items ignored");
+  assert.strictEqual(
+    resolveReleaseSummary(rel, feeds),
+    "tt-forge-onnx released 1.3.0. Repository: https://github.com/tenstorrent/tt-forge-onnx",
+    "non-release items ignored"
+  );
   console.log("✓ resolveReleaseSummary: ignores non-release feed items");
 }
 


### PR DESCRIPTION
This pull request significantly improves the quality and usability of the project's Atom and JSON feeds by enriching feed content, wiring in LLM-generated release summaries, and introducing a new machine-readable `llms.txt` index. The changes ensure that each feed item now carries both a clean one-line summary and a full rich HTML content block, enhancing both human and machine consumption. The README and code are updated to document and support these new capabilities.

**Feed Content Enrichment:**
- Added a new `buildFeedContentHtml` function and Eleventy filter to generate a rich HTML `<content>` block for each feed item, including description, links, attribution, and tags, with safe markdown rendering and HTML escaping. This block is now used in all Atom and JSON feeds. [[1]](diffhunk://#diff-c306e0a99961a16f5c5c83996caa0958b94006d97f97475049ea3a08036bb5b0R21-R112) [[2]](diffhunk://#diff-c306e0a99961a16f5c5c83996caa0958b94006d97f97475049ea3a08036bb5b0R132-R155)
- Updated feed item generation (`jsonFeedItems`, release and entry items) to use the new rich content block and to pass all necessary fields for consistent rendering. [[1]](diffhunk://#diff-c306e0a99961a16f5c5c83996caa0958b94006d97f97475049ea3a08036bb5b0R271-R276) [[2]](diffhunk://#diff-c306e0a99961a16f5c5c83996caa0958b94006d97f97475049ea3a08036bb5b0L180-R308) [[3]](diffhunk://#diff-c306e0a99961a16f5c5c83996caa0958b94006d97f97475049ea3a08036bb5b0L212-R343) [[4]](diffhunk://#diff-c306e0a99961a16f5c5c83996caa0958b94006d97f97475049ea3a08036bb5b0L237-R362)

**Release Summaries:**
- Release feed items now use LLM-generated rich summaries from `planet_feeds.json` when available, falling back to the previous plain string only if no summary is found. This affects both Atom and JSON feeds.

**Machine-Readable Index:**
- Added a new `/llms.txt` resource, a plain-text, category-organized index for LLMs and AI tooling, generated alongside the feeds.

**Documentation:**
- Updated the `README.md` and the README generator script to document the new feeds, the enriched `<content>` blocks, and the new `llms.txt` resource. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R482-R494) [[2]](diffhunk://#diff-eceb85d77db99e6f8edbaf868feda4f82cd3fe00059f566189cfea9af00a2afaR183-R204)
- Added a detailed design document describing the motivation, architecture, and testing for these feed improvements.

**Other:**
- Added a new project entry (`tt-splat`) to the README.