### PR TITLE
fix: clear stale search on category nav + add empty-state escape hatch

### DIFF
--- a/entries/hw-system/tt-quietbox2-guide.json
+++ b/entries/hw-system/tt-quietbox2-guide.json
@@ -1,0 +1,35 @@
+{
+  "id": "tt-quietbox2-guide",
+  "name": "TT-QuietBox 2 Guide",
+  "description": "Official setup and onboarding guide for the TT-QuietBox 2 — a compact, liquid-cooled AI workstation with four Blackhole accelerators, an AMD Ryzen CPU, 256GB RAM, and 4TB NVMe. Covers hardware specs, first-boot setup, and hands-on learning paths for running pre-loaded models like Qwen3-32B and serving text, image, video, and speech models via tt-inference-server.",
+  "affiliation": "official",
+  "categories": [
+    "hw-system",
+    "guides",
+    "getting-started"
+  ],
+  "tags": [
+    "quietbox",
+    "blackhole",
+    "workstation",
+    "setup",
+    "getting-started",
+    "documentation"
+  ],
+  "links": [
+    {
+      "type": "website",
+      "url": "https://docs.tenstorrent.com/tt-quietbox2-guide",
+      "label": "TT-QuietBox 2 Guide"
+    }
+  ],
+  "hardware": [
+    "blackhole",
+    "quietbox"
+  ],
+  "related": [
+    "tt-installer",
+    "tt-inference-server"
+  ],
+  "added_at": "2026-06-30"
+}

--- a/entries/kernels/tt-lang.json
+++ b/entries/kernels/tt-lang.json
@@ -4,7 +4,8 @@
   "description": "Python-based DSL that sits between TT-NN and TT-Metalium — expresses custom fused kernels with progressive disclosure, compiling directly to Tensix. Ships an integrated functional simulator (no hardware needed), line-by-line performance metrics, and AI-agent-friendly tooling. Two packages: tt-lang (compiler + hardware, requires ttnn) and tt-lang-sim (simulator only, works on Linux/macOS without Tenstorrent hardware).",
   "affiliation": "official",
   "categories": [
-    "kernels"
+    "kernels",
+    "getting-started"
   ],
   "tags": [
     "dsl",

--- a/src/_data/planet_feeds.json
+++ b/src/_data/planet_feeds.json
@@ -1,5 +1,19 @@
 [
   {
+    "type": "lesson",
+    "source": "docs",
+    "approved": true,
+    "title": "TT-QuietBox 2 Guide",
+    "url": "https://docs.tenstorrent.com/tt-quietbox2-guide",
+    "description": "The official onboarding guide for the **TT-QuietBox 2** — a liquid-cooled desktop workstation with four Blackhole accelerators — is now live, organized into four hands-on learning paths: **Explore** (first look at the hardware and software, 6 chapters), **Run & build** (deploy pre-built models, 6 chapters), **Tinker** (dig into model architectures and the tt-metal / tt-inference-server stack, 6 chapters), and **Customize** (make the workstation your own, 5 chapters). It ships with Qwen3-32B pre-loaded and walks through running text models (Llama 3.x, Qwen3 4B–32B, Gemma 3, GPT-OSS), image generation (FLUX.1, SDXL), video (Mochi 1, Wan2.2), and speech (Whisper-large-v3, SpeechT5) — all served through tt-inference-server.",
+    "date": "2026-06-30",
+    "dateISO": "2026-06-30T00:00:00Z",
+    "label": "docs.tenstorrent.com",
+    "projectName": "TT-QuietBox 2 Guide",
+    "projectId": "tt-quietbox2-guide",
+    "affiliation": "official"
+  },
+  {
     "type": "release",
     "source": "github",
     "approved": true,

--- a/src/_includes/entry-list.njk
+++ b/src/_includes/entry-list.njk
@@ -44,5 +44,10 @@
       {%- endif %}
     </div>
     {%- endfor %}
+    <div class="list-empty" id="list-empty" hidden>
+      <p class="list-empty-msg">No entries match the current filters.</p>
+      <p class="list-empty-count" id="list-empty-count"></p>
+      <button type="button" class="list-empty-btn" onclick="clearListFilters()">Clear filters · show all</button>
+    </div>
   </div>
 </div>

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -637,9 +637,11 @@ function updateListEmptyState(visible, hiddenByFilters) {
 function clearListFilters() {
   activeFilters = new Set(["community", "affiliated", "official"]);
   _clearSearchInputs();
+  // Mirror toggleChip()/syncMobileChips() exactly so the "All" chip state is
+  // computed the same way everywhere.
   document.querySelectorAll(".chip").forEach((c) => {
     const cf = c.dataset.filter;
-    c.classList.toggle("active", cf === "all" ? true : activeFilters.has(cf));
+    c.classList.toggle("active", cf === "all" ? activeFilters.size === 3 : activeFilters.has(cf));
   });
   syncMobileChips();
   applyFilters("");

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -389,7 +389,10 @@ function _applyAuthorFilter(name) {
   document.querySelectorAll(".sidebar-item").forEach((i) => i.classList.remove("active"));
   document.getElementById("list-title").textContent = name;
   _clearDetail();
-  applyFilters(document.getElementById("search").value.toLowerCase().trim());
+  // Drop any leftover cross-category search so the author view isn't narrowed
+  // by a stale query.
+  _clearSearchInputs();
+  applyFilters("");
   if (isMobile()) {
     panes.classList.remove("detail-active");
     panes.classList.add("list-active");
@@ -475,7 +478,10 @@ function _applyCategory(slug, el) {
   document.querySelectorAll(".sidebar-item").forEach((i) => i.classList.remove("active"));
   el.classList.add("active");
   document.getElementById("list-title").textContent = el.textContent.trim();
-  applyFilters(document.getElementById("search").value.toLowerCase().trim());
+  // Drop any leftover cross-category search so the category shows its full
+  // contents instead of being narrowed by a stale query.
+  _clearSearchInputs();
+  applyFilters("");
   _clearDetail();
   if (isMobile()) {
     panes.classList.remove("detail-active");
@@ -530,6 +536,19 @@ function _clearDetail() {
   document.querySelectorAll(".entry-row, .release-row").forEach((r) => r.classList.remove("active"));
 }
 
+/**
+ * Clear both search inputs (desktop + mobile-expanded) without re-filtering.
+ * Called when the user explicitly navigates to a category or author, so a
+ * leftover cross-category search query can't carry over and make the new view
+ * look empty (the "stuck filter" bug).
+ */
+function _clearSearchInputs() {
+  const desktop = document.getElementById("search");
+  if (desktop) desktop.value = "";
+  const mobile = document.getElementById("search-expanded");
+  if (mobile) mobile.value = "";
+}
+
 /* ── Filter chips ───────────────────────────────────────────────────────── */
 
 function toggleChip(chip) {
@@ -558,23 +577,70 @@ function applyFilters(query) {
   // a separate set of rows and the list pane is not visible.
   if (document.getElementById("panes").classList.contains("releases-active")) return;
   let visible = 0;
+  // Entries that belong to the current view (category/author) but are hidden by
+  // the *clearable* filters — affiliation chips and the search query. These are
+  // the ones the "Clear filters" button would bring back.
+  let hiddenByFilters = 0;
   const authorFilter = activeAuthorFilter ? activeAuthorFilter.toLowerCase() : null;
   document.querySelectorAll(".entry-row").forEach((row) => {
     const cats  = (row.dataset.categories || "").split(",");
     const aff   = row.dataset.affiliation;
     const text  = row.dataset.search || "";
-    const show  =
+    // The view scope (category + author) defines the list and is NOT cleared by
+    // the "Clear filters" button.
+    const inScope =
       (!activeCategory || cats.includes(activeCategory)) &&
-      activeFilters.has(aff) &&
-      (!query || text.includes(query)) &&
       (!authorFilter || (row.dataset.author || "") === authorFilter);
+    // Clearable filters layered on top of the scope.
+    const passesClearable =
+      activeFilters.has(aff) &&
+      (!query || text.includes(query));
+    const show = inScope && passesClearable;
     row.classList.toggle("hidden", !show);
     if (show) visible++;
+    else if (inScope) hiddenByFilters++;
   });
   document.getElementById("list-count").textContent = `${visible} entr${visible === 1 ? "y" : "ies"}`;
+  updateListEmptyState(visible, hiddenByFilters);
   // If the active entry is now filtered out, clear the detail panel
   if (activeEntryId) {
     const row = document.querySelector(`.entry-row[data-id="${activeEntryId}"]`);
     if (row && row.classList.contains("hidden")) _clearDetail();
   }
+}
+
+/**
+ * Show or hide the list empty-state. It appears only when the current view has
+ * zero visible entries but some are hidden by clearable filters — i.e. the
+ * "Clear filters" button would actually reveal something. A genuinely empty
+ * category (nothing hidden) shows no escape hatch.
+ */
+function updateListEmptyState(visible, hiddenByFilters) {
+  const empty = document.getElementById("list-empty");
+  if (!empty) return;
+  const show = visible === 0 && hiddenByFilters > 0;
+  empty.hidden = !show;
+  if (show) {
+    const countEl = document.getElementById("list-empty-count");
+    if (countEl) {
+      countEl.textContent =
+        `${hiddenByFilters} ${hiddenByFilters === 1 ? "entry is" : "entries are"} hidden by active filters.`;
+    }
+  }
+}
+
+/**
+ * Reset the clearable filters (affiliation chips → all on, search query → empty)
+ * while staying in the current category/author view, then re-filter so every
+ * in-scope entry becomes visible. Wired to the empty-state "Clear filters" button.
+ */
+function clearListFilters() {
+  activeFilters = new Set(["community", "affiliated", "official"]);
+  _clearSearchInputs();
+  document.querySelectorAll(".chip").forEach((c) => {
+    const cf = c.dataset.filter;
+    c.classList.toggle("active", cf === "all" ? true : activeFilters.has(cf));
+  });
+  syncMobileChips();
+  applyFilters("");
 }

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -111,6 +111,16 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 .entry-row:hover  { background: var(--bg1); }
 .entry-row.active { background: var(--bg1); border-left-color: var(--teal); }
 .entry-row.hidden { display: none; }
+/* ── List empty-state (filters hide everything) ──────────────────────────── */
+.list-empty        { padding: 32px 18px; text-align: center; }
+.list-empty[hidden]{ display: none; }
+.list-empty-msg    { font-size: 12px; font-weight: 600; color: var(--text); margin: 0 0 4px; }
+.list-empty-count  { font-size: 11px; color: var(--muted); margin: 0 0 12px; }
+.list-empty-btn    { font: inherit; font-size: 11px; font-weight: 600; cursor: pointer;
+                     padding: 6px 14px; border-radius: 6px; border: 1px solid var(--bg2);
+                     background: var(--bg1); color: var(--teal-lt); transition: background 0.1s; }
+.list-empty-btn:hover         { background: var(--bg2); }
+.list-empty-btn:focus-visible { outline: 2px solid var(--teal); outline-offset: 1px; }
 .row-top  { display: flex; align-items: center; gap: 6px; margin-bottom: 2px; }
 .row-name { font-size: 12px; font-weight: 600; color: var(--text); }
 .row-stars{ font-size: 10px; color: var(--teal-lt); white-space: nowrap; padding-left: 4px; }


### PR DESCRIPTION
## Summary

Fixes a filtering bug reported in the directory UI and adds an escape hatch for empty lists, plus a few data additions.

### Bug: stuck search filter
When you searched, clicked into a result, then browsed to a category, the category appeared empty. Root cause: `_applyCategory` / `_applyAuthorFilter` re-ran `applyFilters()` using the **live search box value**, which still held the old query — so the category was narrowed by a stale search. They now clear both search inputs (desktop + mobile-expanded) before filtering.

### Feature: empty-state "Clear filters" button
When a list has zero visible entries *but* some are hidden by clearable filters (affiliation chips and/or search query), an empty-state now appears:
- shows **"N entries are hidden by active filters."**
- a **"Clear filters · show all"** button resets the chips to all-on and clears the search, staying in the current category.

It deliberately does **not** show for a genuinely empty category (nothing to reveal).

### Data additions
- **tt-lang** → added to the 🚀 Getting Started category.
- **TT-QuietBox 2 Guide** → new entry (`entries/hw-system/tt-quietbox2-guide.json`) for `docs.tenstorrent.com/tt-quietbox2-guide`, categorized hw-system → guides → getting-started.
- **Planet** → a `lesson` item summarizing the guide's four learning paths (Explore / Run & build / Tinker / Customize) and the models it covers; linked back to the directory entry.

## Verification
- Loaded the real `src/assets/main.js` under a DOM stub and drove the exact bug scenario — **11/11 checks pass** (search cleared on category nav; empty-state shows correct hidden count; Clear filters restores entries).
- `python3 scripts/validate.py` → no errors (112 entries; pre-existing warning on tt-splat only).
- `fetch_planet_feeds.py --dry-run` → preserves the manual Planet item (193 items, 0 new).
- Eleventy builds clean; entries render under Getting Started and the Planet lesson appears under the Lessons filter.