### PR TITLE
Update tt-rqm-kernels entry routing

### DIFF
--- a/entries/kernels/tt-rqm-kernels.json
+++ b/entries/kernels/tt-rqm-kernels.json
@@ -14,8 +14,18 @@
     },
     {
       "type": "website",
+      "url": "https://github.com/RQM-Technologies-dev/tt-rqm-kernels/blob/main/docs/tenstorrent-landing.md",
+      "label": "Tenstorrent landing page"
+    },
+    {
+      "type": "website",
       "url": "https://github.com/RQM-Technologies-dev/tt-rqm-kernels/blob/main/docs/structuredbench-spec.md",
       "label": "StructuredBench specification"
+    },
+    {
+      "type": "website",
+      "url": "https://github.com/RQM-Technologies-dev/tt-rqm-kernels/blob/main/reports/tt_emule_qmul_candidate.md",
+      "label": "tt-emule qmul candidate report"
     },
     {
       "type": "website",
@@ -48,6 +58,6 @@
   ],
   "author": "RQM-Technologies-dev",
   "language": "Python",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "added_at": "2026-07-03"
 }


### PR DESCRIPTION
## Summary

Update the existing `tt-rqm-kernels` entry so it routes Tenstorrent readers to the current landing page and validation evidence.

## Changes

- Add the Tenstorrent landing page link.
- Add the tt-emule qmul candidate report link.
- Update the license metadata from `MIT` to `Apache-2.0` to match the repository.

## Validation

- `python3 scripts/validate.py`
