### PR TITLE
feat: add libtt and ttPseudoRowMajor community entries

### DIFF
--- a/entries/compilers/libtt.json
+++ b/entries/compilers/libtt.json
@@ -1,0 +1,24 @@
+{
+  "id": "libtt",
+  "name": "libtt",
+  "description": "A Bazel-built PJRT plugin (libtt.so) providing an XLA backend for Tenstorrent devices. Bundles the tt-xla PJRT implementation with tt-mlir and tt-metal into a single shared object so JAX code runs on Tenstorrent hardware, with patches so sglang-jax works out of the box.",
+  "affiliation": "community",
+  "categories": [
+    "compilers"
+  ],
+  "tags": [
+    "xla",
+    "pjrt",
+    "jax",
+    "bazel",
+    "sglang"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/pcmoritz/libtt"
+    }
+  ],
+  "author": "Philipp Moritz",
+  "added_at": "2026-07-10"
+}

--- a/entries/kernels/ttprm.json
+++ b/entries/kernels/ttprm.json
@@ -1,5 +1,5 @@
 {
-  "id": "ttpseudorowmajor",
+  "id": "ttprm",
   "name": "ttPseudoRowMajor",
   "description": "A small TTNN-facing C++ library (ttprm) for running view-shaped tensor work without first materializing the view in DRAM. Targets Tenstorrent TILE tensors and uses cached device operations to gather/scatter through layout views.",
   "affiliation": "community",

--- a/entries/kernels/ttpseudorowmajor.json
+++ b/entries/kernels/ttpseudorowmajor.json
@@ -1,0 +1,26 @@
+{
+  "id": "ttpseudorowmajor",
+  "name": "ttPseudoRowMajor",
+  "description": "A small TTNN-facing C++ library (ttprm) for running view-shaped tensor work without first materializing the view in DRAM. Targets Tenstorrent TILE tensors and uses cached device operations to gather/scatter through layout views.",
+  "affiliation": "community",
+  "categories": [
+    "kernels"
+  ],
+  "tags": [
+    "ttnn",
+    "tensor",
+    "tile",
+    "layout",
+    "cpp"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/marty1885/ttPseudoRowMajor"
+    }
+  ],
+  "author": "Martin Chang",
+  "language": "C++",
+  "license": "Apache-2.0",
+  "added_at": "2026-07-10"
+}


### PR DESCRIPTION
This pull request adds two new community-contributed entries: a PJRT plugin for Tenstorrent hardware and a C++ library for efficient tensor view operations. These additions expand the catalog of available compilers and kernels for Tenstorrent devices.

**New compiler entry:**
* Added `libtt` entry describing a Bazel-built PJRT plugin (`libtt.so`) that provides an XLA backend for Tenstorrent devices, enabling JAX code to run on Tenstorrent hardware.

**New kernel entry:**
* Added `ttPseudoRowMajor` entry for a C++ library (`ttprm`) that allows running view-shaped tensor operations on Tenstorrent TILE tensors without materializing views in DRAM, using cached device operations.- libtt (compilers) — Philipp Moritz's Bazel-built PJRT/XLA backend bundling tt-xla/tt-mlir/tt-metal to run JAX on Tenstorrent
- ttPseudoRowMajor (kernels) — Martin Chang's TTNN C++ library for view-shaped tensor ops without materializing views in DRAM

Both community, non-fork; id ttpseudorowmajor slugified from the mixed-case repo name (display name keeps ttPseudoRowMajor).