### PR TITLE
fix: repair connpass feed, add bilingual EN+JA summaries, deploy on bot-PR merge

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,11 @@ jobs:
             src/_data/github_meta.json
             src/_data/planet_feeds.json
             README.md
-          commit-message: "chore: update GitHub metadata [skip ci]"
+          # No [skip ci]: single-commit PRs squash-merge with this message as
+          # the commit title, and it must not suppress the Pages deploy on main.
+          # (The bot's own branch pushes use GITHUB_TOKEN, which never triggers
+          # workflows, so [skip ci] added nothing there.)
+          commit-message: "chore: update GitHub metadata"
           branch: "chore/nightly-github-metadata"
           delete-branch: true
           title: "chore: update GitHub metadata"

--- a/.github/workflows/planet-feeds.yml
+++ b/.github/workflows/planet-feeds.yml
@@ -23,7 +23,11 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           add-paths: src/_data/planet_feeds.json
-          commit-message: "chore: update planet feeds [skip ci]"
+          # No [skip ci]: single-commit PRs squash-merge with this message as
+          # the commit title, and it must not suppress the Pages deploy on main.
+          # (The bot's own branch pushes use GITHUB_TOKEN, which never triggers
+          # workflows, so [skip ci] added nothing there.)
+          commit-message: "chore: update planet feeds"
           branch: "chore/nightly-planet-feeds"
           delete-branch: true
           title: "chore: update planet feeds"

--- a/.github/workflows/planet-feeds.yml
+++ b/.github/workflows/planet-feeds.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: actions/setup-python@v5
         with: { python-version: "3.11" }
       - name: Fetch planet feeds
+        env:
+          # Optional — used to render connpass event descriptions as bilingual
+          # EN + JA summaries. The fetcher degrades to Japanese-only without it.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: python3 scripts/fetch_planet_feeds.py
       - name: Create pull request if changed
         uses: peter-evans/create-pull-request@v7

--- a/scripts/fetch_planet_feeds.py
+++ b/scripts/fetch_planet_feeds.py
@@ -336,8 +336,12 @@ def bilingual_description(text: str) -> str:
         en = str(parts.get("en", "")).strip()
         ja = str(parts.get("ja", "")).strip()
         if en and ja:
-            return f"{en} — {ja}"
+            # Hard-clamp to the promised 200 chars per language — the prompt
+            # asks for it, but the contract shouldn't depend on model behavior.
+            return f"{truncate(en, 200)} — {truncate(ja, 200)}"
         print("  WARN bilingual_description: model reply missing en/ja", file=sys.stderr)
+    except urllib.error.HTTPError as e:
+        print(f"  WARN bilingual_description: HTTP {e.code}", file=sys.stderr)
     except Exception as e:
         print(f"  WARN bilingual_description: {e}", file=sys.stderr)
     return ""
@@ -356,10 +360,17 @@ def fetch_connpass(known_urls: set) -> list:
             title     = (entry.findtext(f"{{{NS_ATOM}}}title") or "").strip()
             published = (entry.findtext(f"{{{NS_ATOM}}}published") or
                          entry.findtext(f"{{{NS_ATOM}}}updated") or "")
-            link_el = (entry.find(f"{{{NS_ATOM}}}link[@rel='alternate'][@type='text/html']")
-                       or entry.find(f"{{{NS_ATOM}}}link[@rel='alternate']")
-                       or entry.find(f"{{{NS_ATOM}}}link[@type='text/html']")
-                       or entry.find(f"{{{NS_ATOM}}}link"))
+            # NB: pick the first non-None match explicitly — `or`-chaining
+            # Elements doesn't work (childless ones are falsy), which would
+            # defeat this preference order and always take the last fallback.
+            link_el = None
+            for path in (f"{{{NS_ATOM}}}link[@rel='alternate'][@type='text/html']",
+                         f"{{{NS_ATOM}}}link[@rel='alternate']",
+                         f"{{{NS_ATOM}}}link[@type='text/html']",
+                         f"{{{NS_ATOM}}}link"):
+                link_el = entry.find(path)
+                if link_el is not None:
+                    break
             url       = ""
             if link_el is not None:
                 url = link_el.get("href") or link_el.text or ""

--- a/scripts/fetch_planet_feeds.py
+++ b/scripts/fetch_planet_feeds.py
@@ -9,7 +9,9 @@ Sources:
   - arXiv papers mentioning Tenstorrent (trusted — auto-approved, skips entries already curated)
   - r/tenstorrent subreddit (reviewed — auto-approved)
   - Community blogs (reviewed — auto-approved)
-  - Connpass events — Tenstorrent Japan Tech Talk series (trusted — auto-approved)
+  - Connpass events — Tenstorrent Japan Tech Talk series (trusted — auto-approved).
+    Descriptions are condensed into a bilingual EN + JA summary (~200 chars each)
+    via the Anthropic API when ANTHROPIC_API_KEY is set; Japanese-only otherwise.
 
 Items are appended to src/_data/planet_feeds.json. All items (new and
 existing) are written with approved=True so they appear on the Planet
@@ -20,8 +22,10 @@ Usage:
 """
 
 import json
+import os
 import re
 import sys
+import urllib.error
 import urllib.request
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -45,10 +49,29 @@ COMMUNITY_FEEDS = [
     {"name": "anuraagw.me",    "url": "https://anuraagw.me/atom.xml",              "affiliation": "community", "trusted": True},
 ]
 CONNPASS_FEEDS = [
-    {"name": "Tenstorrent Japan", "url": "https://tenstorrent.connpass.com/feed.atom", "affiliation": "official", "trusted": True},
+    # Connpass serves group feeds at /ja.atom (there is no /feed.atom — it 404s).
+    {"name": "Tenstorrent Japan", "url": "https://tenstorrent.connpass.com/ja.atom", "affiliation": "official", "trusted": True},
 ]
 
 USER_AGENT = "tt-awesome-planet/1.0 (github.com/tenstorrent/tt-awesome)"
+
+# Anthropic Messages API — condenses Japanese connpass event descriptions into
+# a short bilingual (EN + JA) summary. Optional: when ANTHROPIC_API_KEY is
+# unset (e.g. local runs, forks) the fetcher keeps the plain Japanese text.
+INFERENCE_URL     = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_VERSION = "2023-06-01"
+TRANSLATE_MODEL   = "claude-haiku-4-5-20251001"
+ANTHROPIC_KEY     = os.environ.get("ANTHROPIC_API_KEY", "")
+
+TRANSLATE_SYSTEM_PROMPT = (
+    "You summarize Japanese tech-event descriptions for Planet Tenstorrent, an "
+    "English-first aggregator that also has Japanese-speaking readers. Reply "
+    "with a JSON object only — no code fences, no commentary — of the form "
+    '{"en": "...", "ja": "..."}. Each value is a summary of the event in that '
+    "language, at most 200 characters, covering the topic and (when present) "
+    "the date, format (online/offline/hybrid), and venue. Plain text only — "
+    "no markdown, no URLs."
+)
 
 NS_ATOM  = "http://www.w3.org/2005/Atom"
 NS_MEDIA = "http://search.yahoo.com/mrss/"
@@ -288,6 +311,38 @@ def fetch_community_feed(feed: dict, known_urls: set) -> list:
     return items
 
 
+def bilingual_description(text: str) -> str:
+    """Condense a Japanese event description into "≤200-char EN — ≤200-char JA".
+
+    Returns "" when ANTHROPIC_API_KEY is unset or the call fails, so callers
+    can fall back to the untranslated text.
+    """
+    if not (ANTHROPIC_KEY and text):
+        return ""
+    payload = json.dumps({
+        "model": TRANSLATE_MODEL,
+        "max_tokens": 500,
+        "system": TRANSLATE_SYSTEM_PROMPT,
+        "messages": [{"role": "user", "content": text}],
+    }).encode()
+    req = urllib.request.Request(INFERENCE_URL, data=payload, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("x-api-key", ANTHROPIC_KEY)
+    req.add_header("anthropic-version", ANTHROPIC_VERSION)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            reply = json.loads(r.read())["content"][0]["text"].strip()
+        parts = json.loads(reply)
+        en = str(parts.get("en", "")).strip()
+        ja = str(parts.get("ja", "")).strip()
+        if en and ja:
+            return f"{en} — {ja}"
+        print("  WARN bilingual_description: model reply missing en/ja", file=sys.stderr)
+    except Exception as e:
+        print(f"  WARN bilingual_description: {e}", file=sys.stderr)
+    return ""
+
+
 def fetch_connpass(known_urls: set) -> list:
     items = []
     for feed in CONNPASS_FEEDS:
@@ -309,13 +364,25 @@ def fetch_connpass(known_urls: set) -> list:
             if link_el is not None:
                 url = link_el.get("href") or link_el.text or ""
             url = url.strip()
+            # The feed appends utm_* tracking params to every event link;
+            # drop them so stored URLs are clean and dedup stays stable.
+            if "?" in url:
+                base, _, query = url.partition("?")
+                kept = [p for p in query.split("&") if p and not p.startswith("utm_")]
+                url = base + ("?" + "&".join(kept) if kept else "")
             if not url or url in known_urls:
                 continue
             known_urls.add(url)
-            summary_el = (entry.find(f"{{{NS_ATOM}}}summary") or
-                          entry.find(f"{{{NS_ATOM}}}content"))
+            # NB: use `is None`, not `or` — ElementTree Elements with no
+            # children are falsy even when they carry text.
+            summary_el = entry.find(f"{{{NS_ATOM}}}summary")
+            if summary_el is None:
+                summary_el = entry.find(f"{{{NS_ATOM}}}content")
             raw  = summary_el.text if summary_el is not None else ""
             desc = truncate(strip_html(raw))
+            # Connpass descriptions are Japanese; offer readers a bilingual
+            # summary when the API key is available (JA-only fallback otherwise).
+            desc = bilingual_description(desc) or desc
             date_str = iso_to_date(published)
             items.append({
                 "type":        "talk",

--- a/src/_data/planet_feeds.json
+++ b/src/_data/planet_feeds.json
@@ -56,6 +56,20 @@
     "affiliation": "official"
   },
   {
+    "type": "talk",
+    "source": "connpass",
+    "approved": true,
+    "title": "Tenstorrent Tech Talk #9",
+    "url": "https://tenstorrent.connpass.com/event/400605/",
+    "description": "Developer meetup on RISC-V: 2025–26 industry trends, an intro to the Vector Extension (RVV), and Tenstorrent's Ascalon CPU chiplet development and performance. Hybrid — Aug 27, 2026, Tokyo & online. — Tenstorrent社員が解説する開発者向け技術交流会。今回のテーマはRISC-V。業界の最新動向、ベクトル拡張（RVV）入門、RISC-VベースCPUチップレット「Ascalon」の開発と性能評価を紹介。2026年8月27日、東京オフィス＆オンラインのハイブリッド開催、参加費無料。",
+    "date": "2026-07-15",
+    "dateISO": "2026-07-15T13:01:30+09:00",
+    "label": "Tenstorrent Japan — connpass",
+    "projectName": "Tenstorrent Japan",
+    "projectId": null,
+    "affiliation": "official"
+  },
+  {
     "type": "release",
     "source": "github",
     "approved": true,


### PR DESCRIPTION
## Summary

Three related fixes to the Planet feeds pipeline.

### 1. The connpass integration from #126 never produced entries

Two bugs in `scripts/fetch_planet_feeds.py`:
- The feed URL pointed at `tenstorrent.connpass.com/feed.atom`, which returns a 404 — connpass serves group feeds at `/ja.atom`
- `entry.find(summary) or entry.find(content)` silently skipped the `<summary>` element: ElementTree elements with no children are falsy even when they carry text, so descriptions came back empty. Now uses explicit `is None` checks

Also strips the feed's `utm_*` tracking params from event URLs so clean URLs land in the data and dedup stays stable.

### 2. Bilingual EN + JA event descriptions

Japanese connpass descriptions are condensed into a bilingual **EN + JA summary (~200 chars each)** via the Anthropic API (Haiku, same pattern as `summarize_releases.py`). Degrades gracefully to Japanese-only when `ANTHROPIC_API_KEY` is unset (local runs, forks). `planet-feeds.yml` now passes the existing secret to the fetch step.

Data change: adds the most recent event, **Tenstorrent Tech Talk #9** (RISC-V themed, hybrid, Aug 27 2026, Tokyo), as a 🎤 talk entry with a hand-written bilingual description in the pipeline's format.

### 3. Pages site now rebuilds when bot PRs merge

The nightly bot PRs carried `[skip ci]` in their commit message; single-commit PRs squash-merge with that message as the commit title, which suppressed the Pages deploy on main — merged feed refreshes never went live. Removed it (it bought nothing on the bot branches: `create-pull-request` pushes with `GITHUB_TOKEN`, whose events never trigger workflows).

### Note

Now that the feed URL works, the next scheduled feed run will also pull the 9 older connpass events (Tech Talks #1–#8 plus a Macnica seminar). If those shouldn't appear, the fetcher needs a date cutoff before this merges.

## Test plan

- [x] Eleventy build succeeds; entry renders on `/planet/` with the talk filter chip
- [x] `node --test tests/*.js` — 4 pass
- [x] `python3 -m pytest tests/` — 77 pass
- [x] No-key fallback of `bilingual_description()` returns `""` without raising
- [ ] First live exercise of the translation path happens on the next scheduled `planet-feeds` run
- [ ] Verify Pages deploy fires after the next bot PR merge