### PR TITLE
Fix spacing around 'Fresh from Planet Tenstorrent' heading

### DIFF
--- a/src/_includes/home.njk
+++ b/src/_includes/home.njk
@@ -53,7 +53,7 @@
     {%- endfor %}
   </div>
 
-  <div class="home-section-label">Fresh from Planet Tenstorrent</div>
+  <div class="home-section-label home-section-label--spaced">Fresh from Planet Tenstorrent</div>
   <div class="home-planet">
     <p class="home-planet-blurb">
       <strong>Planet Tenstorrent</strong> is the ecosystem's live feed — new releases,

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -247,6 +247,10 @@ a.pkg-dot:hover { filter: brightness(1.3); }
 /* Section label above the grid */
 .home-section-label { font-size: 9px; letter-spacing: 2px; text-transform: uppercase;
                       color: var(--muted); margin-bottom: 16px; }
+/* Extra breathing room *above* a section label that follows a preceding block
+   (e.g. the Planet teaser under the category grid) — separates it from what's
+   above while keeping the standard 16px gap to its own results below. */
+.home-section-label--spaced { margin-top: 48px; }
 
 /* Category card grid */
 .cat-grid { display: grid;
@@ -285,7 +289,7 @@ a.pkg-dot:hover { filter: brightness(1.3); }
 /* ── Planet Tenstorrent teaser below the category grid ────────────────────
    The 5 newest planet items as FULL cards — same planet-item.njk include and
    planet-item.css component the planet page uses (YouTube embeds included). */
-.home-planet { margin-top: 40px; padding-bottom: 24px; }
+.home-planet { margin-top: 4px; padding-bottom: 24px; }
 .home-planet-blurb { font-size: 12px; color: var(--text2); line-height: 1.6;
                      margin-bottom: 14px; }
 .home-planet-more  { display: inline-block; margin-top: 4px; font-size: 12px;


### PR DESCRIPTION
## Problem

The "Fresh from Planet Tenstorrent" heading on the home page sits **too close to the category grid above it** and **too far from its own results below** (see screenshot in the issue).

PR #134 attempted to fix this by setting `.home-planet { margin-top: 40px }`. But the heading (`.home-section-label`) is a sibling **before** `.home-planet` in the DOM — so that margin collapsed with the label's `margin-bottom: 16px` and pushed the heading **40px away from its own results**, while the gap *above* the heading stayed untouched. The net effect was the opposite of what was intended.

## Fix

- Revert `.home-planet` `margin-top` back to `4px`, restoring the standard 16px label→results gap (matching the "Browse by category" section).
- Add a scoped `.home-section-label--spaced` modifier (`margin-top: 48px`) applied only to the Planet heading, pushing it down away from the category grid above.

This keeps the heading visually attached to its results while giving it breathing room from the section above — without affecting the other section labels.

## Verification

Built locally with `eleventy --serve` and confirmed the modifier class and CSS values in the compiled `_site` output.