### PR TITLE
feat: add seven entries; widen official affiliation to TT-owned orgs

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-entry.yml
+++ b/.github/ISSUE_TEMPLATE/submit-entry.yml
@@ -38,8 +38,11 @@ body:
       description: >
         `community` = not employed by Tenstorrent.
         `affiliated` = Tenstorrent employee, personal capacity.
-        `official` = lives under a Tenstorrent-owned GitHub org (`tenstorrent`,
-        `tenstorrent-riscv-software`, `tenstorrent-metal`, `tenstorrent-forks`).
+        `official` = lives under any Tenstorrent-owned GitHub org — for example
+        `tenstorrent`, `tenstorrent-riscv-software`, `tenstorrent-metal`, or
+        `tenstorrent-forks`. Those are examples, not the full list: a repo in any
+        other Tenstorrent-owned org is also `official`, so pick it and mention the
+        org in your submission.
       options:
         - community
         - affiliated

--- a/.github/ISSUE_TEMPLATE/submit-entry.yml
+++ b/.github/ISSUE_TEMPLATE/submit-entry.yml
@@ -38,7 +38,8 @@ body:
       description: >
         `community` = not employed by Tenstorrent.
         `affiliated` = Tenstorrent employee, personal capacity.
-        `official` = lives under the `tenstorrent` GitHub org.
+        `official` = lives under a Tenstorrent-owned GitHub org (`tenstorrent`,
+        `tenstorrent-riscv-software`, `tenstorrent-metal`, `tenstorrent-forks`).
       options:
         - community
         - affiliated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,23 @@ Every entry must be valid against this schema:
 | Value | Who qualifies |
 |---|---|
 | `community` | Anyone not employed by Tenstorrent |
-| `affiliated` | Tenstorrent employees contributing in a personal capacity (e.g. personal GitHub repos, not under the tenstorrent org) |
-| `official` | Repositories in the `tenstorrent` GitHub org |
+| `affiliated` | Tenstorrent employees contributing in a personal capacity (e.g. personal GitHub repos, not under a Tenstorrent-owned org) |
+| `official` | Repositories in any Tenstorrent-owned GitHub org |
+
+### Tenstorrent-owned orgs
+
+`official` is not limited to the `tenstorrent` org. Tenstorrent publishes code from
+several orgs, and a repo in any of them qualifies:
+
+| Org | What lives there |
+|---|---|
+| [`tenstorrent`](https://github.com/tenstorrent) | The main org — tt-metal, tt-forge, tt-kmd, and most of the stack |
+| [`tenstorrent-riscv-software`](https://github.com/tenstorrent-riscv-software) | RISC-V software work, e.g. `tt-bh-linux` |
+| [`tenstorrent-metal`](https://github.com/tenstorrent-metal) | Older Metal-era repos |
+| [`tenstorrent-forks`](https://github.com/tenstorrent-forks) | Tenstorrent's public forks of upstream projects |
+
+If you hit a Tenstorrent-owned org that isn't listed here, it still counts as
+`official` — please add it to this table in the same PR.
 
 **Community entries are shown first** in every category. This is intentional — the goal is to surface what the community has built, not to be an index of official repos.
 

--- a/entries/agents/tenstorrent-console-skill.json
+++ b/entries/agents/tenstorrent-console-skill.json
@@ -15,7 +15,7 @@
     "tenstorrent-console",
     "inference-api",
     "text-to-video",
-    "wan2.2",
+    "wan2-2",
     "korean"
   ],
   "links": [

--- a/entries/agents/tenstorrent-console-skill.json
+++ b/entries/agents/tenstorrent-console-skill.json
@@ -1,0 +1,34 @@
+{
+  "id": "tenstorrent-console-skill",
+  "name": "Tenstorrent Console Skill",
+  "description": "An agent skill (SKILL.md) that teaches Claude Code, Codex, and the Agent SDK how to drive the console.tenstorrent.com inference API: OpenAI-compatible chat with DeepSeek-R1 and Qwen3, async image jobs, and Wan 2.2 text-to-video. Ships runnable curl examples and a mock-curl test harness; documentation is bilingual Korean/English.",
+  "affiliation": "community",
+  "categories": [
+    "agents",
+    "dev-tools"
+  ],
+  "tags": [
+    "agent-skill",
+    "claude-code",
+    "codex",
+    "agent-sdk",
+    "tenstorrent-console",
+    "inference-api",
+    "text-to-video",
+    "wan2.2",
+    "korean"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/aldegad/tenstorrent"
+    }
+  ],
+  "related": [
+    "tenstorrent-cli"
+  ],
+  "author": "aldegad",
+  "language": "Shell",
+  "license": "MIT",
+  "added_at": "2026-08-10"
+}

--- a/entries/compilers/tt-tinygrad.json
+++ b/entries/compilers/tt-tinygrad.json
@@ -1,0 +1,34 @@
+{
+  "id": "tt-tinygrad",
+  "name": "tt-tinygrad",
+  "description": "A Tenstorrent backend for tinygrad that targets TT-Lang rather than raw tt-metal: a Renderer classifies each UOp kernel graph as matmul, reduce, or elementwise and emits ttl.math.* Python source, and a Compiled device parses the rendered kernel's contract, materializes ttnn tensors from host buffers, and calls it in-process. Proof of concept — 110 pass / 13 xfail across 125 cases on a QuietBox, covering fused matmul, reductions, softmax, layernorm, and attention chains, on top of a three-line patch to upstream tinygrad.",
+  "affiliation": "community",
+  "categories": [
+    "compilers"
+  ],
+  "tags": [
+    "tinygrad",
+    "tt-lang",
+    "ttnn",
+    "backend",
+    "codegen",
+    "renderer",
+    "python"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/Gogopex/tt-tinygrad"
+    }
+  ],
+  "hardware": [
+    "wormhole",
+    "quietbox"
+  ],
+  "related": [
+    "tt-lang"
+  ],
+  "author": "Gogopex",
+  "language": "Python",
+  "added_at": "2026-08-10"
+}

--- a/entries/dev-tools/tenstorrent-cli.json
+++ b/entries/dev-tools/tenstorrent-cli.json
@@ -1,0 +1,31 @@
+{
+  "id": "tenstorrent-cli",
+  "name": "tenstorrent-cli",
+  "description": "A TypeScript/Bun terminal client for console.tenstorrent.com. Opens a chat REPL across DeepSeek-R1, Qwen3-32B, Qwen3-VL, and Gemma, with slash commands that submit image, Wan 2.2 video, TTS, and STT jobs, poll them, and save the results under ./output. Reads its API key only from the TENSTORRENT_KEY environment variable — never from disk.",
+  "affiliation": "community",
+  "categories": [
+    "dev-tools"
+  ],
+  "tags": [
+    "cli",
+    "repl",
+    "typescript",
+    "bun",
+    "tenstorrent-console",
+    "inference-api",
+    "text-to-video"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/aldegad/tenstorrent-cli"
+    }
+  ],
+  "related": [
+    "tenstorrent-console-skill"
+  ],
+  "author": "aldegad",
+  "language": "TypeScript",
+  "license": "MIT",
+  "added_at": "2026-08-10"
+}

--- a/entries/dev-tools/tt-monitor.json
+++ b/entries/dev-tools/tt-monitor.json
@@ -1,0 +1,38 @@
+{
+  "id": "tt-monitor",
+  "name": "tt-monitor",
+  "description": "A translucent, undecorated desktop widget showing live per-chip telemetry for Tenstorrent accelerators: temperature and power sparklines against the card's thermal and TDP limits, AI clock, voltage, current, DRAM channel training and ECC error counts, PCIe link generation/width, and board identity. Reads hardware directly through luwen over /dev/tenstorrent — no Python, no tt-smi subprocess, and no root.",
+  "affiliation": "community",
+  "categories": [
+    "dev-tools",
+    "hw-system"
+  ],
+  "tags": [
+    "telemetry",
+    "monitoring",
+    "widget",
+    "luwen",
+    "gtk4",
+    "rust",
+    "ecc",
+    "desktop"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/antonibertel/tt-monitor"
+    }
+  ],
+  "hardware": [
+    "wormhole",
+    "blackhole"
+  ],
+  "related": [
+    "luwen",
+    "tt-smi"
+  ],
+  "author": "antonibertel",
+  "language": "Rust",
+  "license": "MIT",
+  "added_at": "2026-08-10"
+}

--- a/entries/guides/tensix-field-guide.json
+++ b/entries/guides/tensix-field-guide.json
@@ -1,0 +1,35 @@
+{
+  "id": "tensix-field-guide",
+  "name": "Tensix Field Guide",
+  "description": "A ten-chapter, plain-English tour of Tenstorrent's Tensix architecture written for someone who knows what a CPU and a GPU are and nothing else: the chip-level grid and NoC, the five RISC-V baby cores, the matrix engine and its LoFi/HiFi fidelity trade-off, the SFPU, L1 and circular buffers, and why everything is 32x32 tile-shaped. The goal is to get a newcomer to the point of reading tt-metal kernel code in one sitting. Self-described draft; every claim traces back to tt-metal tech reports, tt-llk docs, or METALIUM_GUIDE.",
+  "affiliation": "community",
+  "categories": [
+    "guides",
+    "riscv-arch"
+  ],
+  "tags": [
+    "tensix",
+    "architecture",
+    "sfpu",
+    "noc",
+    "circular-buffers",
+    "tile-format",
+    "risc-v",
+    "education",
+    "book"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/OrangeTangy/tensix-field-guide"
+    }
+  ],
+  "hardware": [
+    "wormhole",
+    "blackhole"
+  ],
+  "author": "Tanay Anand",
+  "author_url": "https://github.com/OrangeTangy",
+  "license": "CC-BY-4.0",
+  "added_at": "2026-08-10"
+}

--- a/entries/guides/tt-sim-lab.json
+++ b/entries/guides/tt-sim-lab.json
@@ -1,0 +1,53 @@
+{
+  "id": "tt-sim-lab",
+  "name": "tt-sim Lab",
+  "description": "A university teaching lab for TT-Metalium kernel programming on a virtual Tenstorrent chip — one-click GitHub Codespace, no silicon and nothing installed locally. The primary track (labs 00-06) points tt-metal straight at libttsim via TT_METAL_SIMULATOR and walks from elementwise add through NoC multicast to multi-core and multicast matmul, backed by a source-level matmul guide. An optional advanced track (labs 10-16) boots an Ubuntu guest under ttsim-qemu, loads tt-kmd, surfaces /dev/tenstorrent/0, and runs tt-metal through the full PCIe path.",
+  "affiliation": "affiliated",
+  "categories": [
+    "guides",
+    "kernels",
+    "getting-started"
+  ],
+  "tags": [
+    "ttsim",
+    "simulator",
+    "qemu",
+    "codespaces",
+    "metalium",
+    "matmul",
+    "labs",
+    "curriculum",
+    "academia",
+    "education"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/prag79/tt-sim-lab"
+    },
+    {
+      "type": "lesson",
+      "url": "https://github.com/prag79/tt-sim-lab/blob/main/HANDOUT.md",
+      "label": "Student handout"
+    },
+    {
+      "type": "lesson",
+      "url": "https://github.com/prag79/tt-sim-lab/blob/main/labs/MATMUL_GUIDE.md",
+      "label": "Matmul source walkthrough"
+    }
+  ],
+  "hardware": [
+    "ttsim",
+    "wormhole",
+    "blackhole"
+  ],
+  "related": [
+    "ttsim",
+    "ttsim-qemu",
+    "tt-kmd"
+  ],
+  "author": "Pragnajit Datta Roy",
+  "author_url": "https://github.com/prag79",
+  "language": "Shell",
+  "added_at": "2026-08-10"
+}

--- a/entries/kernels/ttwkv7.json
+++ b/entries/kernels/ttwkv7.json
@@ -1,0 +1,30 @@
+{
+  "id": "ttwkv7",
+  "name": "ttWKV7",
+  "description": "A standalone tt-metal demo and test bench for the RWKV-7 (WKV7) state recurrence on Wormhole, built with a GGML backend in mind. Two compute kernels cover the domain: a chunked-parallel DPLR matmul path for any sequence length with on-chip chunk carry, and a sequential per-token decode path for L <= 32 that is faster for large-batch token generation. The host runner validates both against a CPU oracle by PCC/NMSE and benchmarks them over a sequence/batch grid.",
+  "affiliation": "community",
+  "categories": [
+    "kernels"
+  ],
+  "tags": [
+    "rwkv",
+    "wkv7",
+    "operator",
+    "tt-metal",
+    "ggml",
+    "recurrent",
+    "cpp"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/marty1885/ttWKV7"
+    }
+  ],
+  "hardware": [
+    "wormhole"
+  ],
+  "author": "Martin Chang",
+  "language": "C++",
+  "added_at": "2026-08-10"
+}

--- a/entries/riscv-arch/tt-bh-linux.json
+++ b/entries/riscv-arch/tt-bh-linux.json
@@ -16,7 +16,7 @@
   "links": [
     {
       "type": "repo",
-      "url": "https://github.com/tenstorrent/tt-bh-linux"
+      "url": "https://github.com/tenstorrent-riscv-software/tt-bh-linux"
     },
     {
       "type": "website",
@@ -27,7 +27,7 @@
     "blackhole"
   ],
   "featured": true,
-  "language": "C",
-  "license": "GPL-2.0",
+  "language": "C++",
+  "license": "Apache-2.0",
   "added_at": "2026-05-08"
 }

--- a/skills/add-project/SKILL.md
+++ b/skills/add-project/SKILL.md
@@ -58,7 +58,9 @@ For each optional field, ask only once — if the user says "skip", "none", or l
 5. **Affiliation** (required)
    - `community` — not a Tenstorrent employee
    - `affiliated` — Tenstorrent employee, personal capacity
-   - `official` — lives under the `tenstorrent` GitHub org
+   - `official` — lives under a Tenstorrent-owned GitHub org: `tenstorrent`,
+     `tenstorrent-riscv-software`, `tenstorrent-metal`, or `tenstorrent-forks`
+     (infer this from the repo URL rather than asking, when the owner matches)
 
 6. **Hardware tested** (optional)
    - Ask: "Which Tenstorrent hardware has this been tested on? (skip if unsure)"

--- a/skills/add-project/SKILL.md
+++ b/skills/add-project/SKILL.md
@@ -58,9 +58,14 @@ For each optional field, ask only once — if the user says "skip", "none", or l
 5. **Affiliation** (required)
    - `community` — not a Tenstorrent employee
    - `affiliated` — Tenstorrent employee, personal capacity
-   - `official` — lives under a Tenstorrent-owned GitHub org: `tenstorrent`,
-     `tenstorrent-riscv-software`, `tenstorrent-metal`, or `tenstorrent-forks`
-     (infer this from the repo URL rather than asking, when the owner matches)
+   - `official` — lives under any Tenstorrent-owned GitHub org. Known ones, as
+     examples rather than an exhaustive list: `tenstorrent`,
+     `tenstorrent-riscv-software`, `tenstorrent-metal`, `tenstorrent-forks`.
+     - If the repo owner is one of these, infer `official` from the URL instead
+       of asking.
+     - If the owner is some *other* Tenstorrent-owned org, that is still
+       `official` — use it, and tell the user to add that org to the
+       Tenstorrent-owned orgs table in `CONTRIBUTING.md`.
 
 6. **Hardware tested** (optional)
    - Ask: "Which Tenstorrent hardware has this been tested on? (skip if unsure)"


### PR DESCRIPTION
## New entries (7)

Six community, one affiliated. All pass `scripts/validate.py` (141 entries) and were confirmed to render into the expected categories via `generate_data_json.py`.

| Entry | Category | Affiliation | Why it's worth listing |
|---|---|---|---|
| `tenstorrent-console-skill` | agents, dev-tools | community | Agent skill (SKILL.md) teaching Claude Code / Codex / Agent SDK to drive the `console.tenstorrent.com` inference API — chat, image jobs, Wan 2.2 video. Ships curl examples and a mock-curl test harness. |
| `tenstorrent-cli` | dev-tools | community | Bun/TypeScript REPL client for the same API, with slash commands that submit and poll image/video/TTS/STT jobs. |
| `tt-monitor` | dev-tools, hw-system | community | Rust/GTK4 translucent telemetry widget going straight at `luwen` over `/dev/tenstorrent` — no Python, no `tt-smi` subprocess, no root. Reports DRAM channel training and ECC counts, and is candid about what the firmware cannot report. |
| `tt-tinygrad` | compilers | community | tinygrad backend that renders each UOp kernel graph to TT-Lang `ttl.math.*` source rather than raw tt-metal, then runs it through ttnn. PoC at 110 pass / 13 xfail over 125 cases on a QuietBox. |
| `ttwkv7` | kernels | community | RWKV-7 (WKV7) state-recurrence kernels for Wormhole with a GGML backend in mind — chunked-parallel DPLR path plus a sequential decode path, validated against a CPU oracle by PCC/NMSE. |
| `tt-sim-lab` | guides, kernels, getting-started | **affiliated** | University teaching lab: one-click Codespace, 16 labs from elementwise add to multicast matmul on a virtual Wormhole, plus an advanced track that boots Linux under ttsim-qemu and loads tt-kmd. Green CI, all deps public. |
| `tensix-field-guide` | guides, riscv-arch | community | Ten-chapter plain-English Tensix architecture tour — grid and NoC down to the five baby cores, fidelity modes, SFPU, circular buffers, tile format. |

`tt-sim-lab` is `affiliated`, not community: `prag79` is Pragnajit Datta Roy, the same person as `pdroyTT` (Tenstorrent, Functional Simulation Architect), and most commits are authored `pdroy@tenstorrent.com`.

## Fixes to the featured `tt-bh-linux` entry

Found while confirming the repo wasn't already listed (it was):

| Field | Was | Now |
|---|---|---|
| repo URL | `tenstorrent/tt-bh-linux` | `tenstorrent-riscv-software/tt-bh-linux` |
| `language` | `C` | `C++` (50.9KB C++ vs 6.7KB C) |
| `license` | `GPL-2.0` | `Apache-2.0` (confirmed from the LICENSE file) |

Nothing was visibly broken — the old URL 301-redirects, and the nightly metadata fetch kept working because `api.github.com/repos/{repo}` follows renames. It was quietly pointing at a stale path.

## Affiliation policy: `official` now means any TT-owned org

That URL exposed a stale rule. The policy defined `official` as "repositories in the `tenstorrent` GitHub org," so anything published from a satellite org was liable to be mislabeled `community`. Widened to **any Tenstorrent-owned GitHub org**, with the four that carry public code named explicitly:

| Org | Public repos |
|---|---|
| `tenstorrent` | 135 |
| `tenstorrent-riscv-software` | 10 |
| `tenstorrent-metal` | 5 |
| `tenstorrent-forks` | 3 |

Updated in all three places the rule was written down: `CONTRIBUTING.md`, `.github/ISSUE_TEMPLATE/submit-entry.yml`, and `skills/add-project/SKILL.md`. The skill now also infers affiliation from the repo owner instead of asking — the step that would have caught `tt-bh-linux` at submission time. `CONTRIBUTING.md` asks contributors who hit an unlisted TT-owned org to add it to the table in the same PR, so the list maintains itself.

Eight `tenstorrent-*` orgs exist; the other four (`tenstorrent-software`, `tenstorrent-digital`, `tenstorrent-tinytensor`, `tenstorrent-docs-test`) have zero public repos or are test orgs, so listing them would only add noise.

**No code changes were required.** Affiliation is never derived from the org anywhere — `summarize_releases.py` reads it from an `affiliation_map` built off the entry JSON, and the site/README generators only consume the stored value.

## Notes for review

- **Missing licenses upstream.** `tt-sim-lab`, `tt-tinygrad`, and `ttWKV7` have no LICENSE file, so I omitted the field rather than guessing. For `tt-sim-lab` that's worth raising with Pragnajit — a repo meant to be forked into university coursework really needs one. `tensix-field-guide` declares CC-BY-4.0 in its README only, and I recorded it on that authority.
- **`tenstorrent-console-skill` accuracy.** Its SKILL.md describes endpoints the console "exposes or is planned to expose," and the CLI gates `/tts` and `/stt` on "if the endpoint is available." For a skill whose job is telling agents which endpoints exist, worth verifying against the real API before it ever gets `featured`.
- **Naming.** `aldegad/tenstorrent` is a bare `tenstorrent` repo name under a personal account; I titled the entry "Tenstorrent Console Skill" so it doesn't read as official.
- **`tensix-field-guide`** self-labels "Draft v0.1, unverified," which undersells it — I spot-checked ch. 5 and the 4,096-MAC/cycle figure and LoFi/HiFi2–4 fidelity table are correct, with no `[TODO: verify]` markers left in the chapters I sampled. The description notes the draft status and the sourcing.

## Follow-ups not done here

- No validation catches a mislabeled affiliation, which is how `tt-bh-linux` sat wrong. A `validate.py` check for "repo owner is a TT org but affiliation isn't `official`" would close it.
- `docs/superpowers/plans/` and `docs/superpowers/specs/` still carry the old wording. Left as the dated historical record rather than retconned.
- `data.json` / `README.md` untouched — deploy regenerates them.