### PR TITLE
feat: add RISC-V Summit Europe 2026 Tenstorrent HPC talk to the planet feed

### DIFF
--- a/src/_data/planet_feeds.json
+++ b/src/_data/planet_feeds.json
@@ -1470,6 +1470,20 @@
     "affiliation": "official"
   },
   {
+    "type": "video",
+    "source": "youtube",
+    "approved": true,
+    "title": "Evaluating Tenstorrent RISC-V Accelerators For High Performance Scientific Computing | Boella",
+    "url": "https://www.youtube.com/watch?v=DEDSMUgMprE",
+    "description": "Elisabetta Boella of E4 Computer Engineering presents an evaluation of Tenstorrent's RISC-V accelerators as scientific-computing hardware rather than AI-only silicon, in a 17-minute talk recorded at RISC-V Summit Europe 2026. The work behind it is the group's astrophysical N-body porting effort on the Wormhole n300 — which reported roughly 2× speedup and 2× energy savings against a highly optimized CPU implementation — and the follow-up study of strategies for scaling that code across multiple accelerators.",
+    "date": "2026-07-07",
+    "dateISO": "2026-07-07T19:08:36Z",
+    "label": "RISC-V International — YouTube",
+    "projectName": "RISC-V International",
+    "projectId": null,
+    "affiliation": "community"
+  },
+  {
     "type": "release",
     "source": "github",
     "approved": true,


### PR DESCRIPTION
Adds Elisabetta Boella's (E4 Computer Engineering) RISC-V Summit Europe 2026 talk, **"Evaluating Tenstorrent RISC-V Accelerators For High Performance Scientific Computing"**, as a manually curated planet item.

📺 https://www.youtube.com/watch?v=DEDSMUgMprE

### Why hand-curated

The video lives on the **RISC-V International** YouTube channel, which is deliberately *not* added to `YOUTUBE_CHANNELS` in `scripts/fetch_planet_feeds.py` — that channel is far broader than Tenstorrent content, so pulling its whole feed would flood the planet. Hand-curating follows the precedent set by the DSC Europe talk in #149. The fetcher preserves existing items by URL, so the nightly job leaves this one alone (verified with `--dry-run`).

### Field choices

| Field | Value | Why |
|---|---|---|
| `affiliation` | `community` | Boella is at E4 Computer Engineering, not Tenstorrent |
| `dateISO` | `2026-07-07T19:08:36Z` | From the watch page's `publishDate`, converted from `-07:00` |
| `projectName` / `projectId` | `RISC-V International` / `null` | Channel-name convention, matching the DSC item |

### On the description

The YouTube description is only two lines ("At RISC-V Summit Europe 2026 / Elisabetta Boella, E4 Computer Engineering") and captions weren't retrievable, so the blurb is written from the published work behind the talk. Both papers are already entries here — `paper-nbody-wormhole` and `paper-nbody-strategies-wormhole` — and list Boella as an author. The 2× speedup / 2× energy-savings figures are attributed to the paper rather than to the talk itself, since the talk's contents weren't verified.

### Verification

- `npm run validate` — 152 entries valid
- `npm run build` — item renders on `/planet/` with the nocookie embed, `community` badge, and "Jul 7, 2026"
- `node tests/test_entry_pages.js`, `test_data_files.js`, `test_eleventy_filters.js`, `test_recent_releases.js` — all pass
- `python3 scripts/fetch_planet_feeds.py --dry-run` — item preserved, not re-fetched or duplicated
