### PR TITLE
feat: add tt-bio-demo, tt-gozer and tt-demo-maker; pull tsingletarytt.github.io into the planet

### DIFF
--- a/entries/ai-models/tt-bio.json
+++ b/entries/ai-models/tt-bio.json
@@ -30,6 +30,9 @@
     "quietbox",
     "galaxy"
   ],
+  "related": [
+    "tt-bio-demo"
+  ],
   "featured": true,
   "author": "moritztng",
   "language": "Python",

--- a/entries/dev-tools/tt-demo-maker.json
+++ b/entries/dev-tools/tt-demo-maker.json
@@ -1,0 +1,36 @@
+{
+  "id": "tt-demo-maker",
+  "name": "tt-demo-maker",
+  "description": "A project-agnostic toolkit for authoring demo recordings and draft posts from inside any project. Describe scenes in a small YAML manifest and it drives the terminal ballet — tmux, asciinema, VHS, ffmpeg and agg — into asciicast/GIF/MP4 footage plus a first-draft Markdown post pairing each directive with the reaction it caused. Rust orchestrator over bash capture primitives, with idle trimming, readiness gating, and a /tt-demo Claude skill that writes the manifest for you.",
+  "affiliation": "affiliated",
+  "categories": [
+    "dev-tools"
+  ],
+  "tags": [
+    "demo",
+    "recording",
+    "asciinema",
+    "vhs",
+    "automation",
+    "tui",
+    "claude-code",
+    "developer-experience"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/tsingletaryTT/tt-demo-maker"
+    }
+  ],
+  "hardware": [
+    "blackhole",
+    "quietbox"
+  ],
+  "related": [
+    "tt-toplike"
+  ],
+  "author": "tsingletaryTT",
+  "language": "Rust",
+  "license": "Apache-2.0",
+  "added_at": "2026-08-19"
+}

--- a/entries/dev-tools/tt-gozer.json
+++ b/entries/dev-tools/tt-gozer.json
@@ -1,0 +1,34 @@
+{
+  "id": "tt-gozer",
+  "name": "tt-gozer",
+  "description": "Cooperative chip leasing for Tenstorrent boxes, so several agents — Claude Code sessions, aider, shell scripts, cron jobs — can share one machine without corrupting each other's runs. A lease records who is using which chips and why; the kernel's view of the devices is the tiebreaker when the two disagree. Standard-library Python, board-grain leases by default, and it ships Claude Code skills that teach agents to lease before they run.",
+  "affiliation": "affiliated",
+  "categories": [
+    "dev-tools",
+    "hw-system"
+  ],
+  "tags": [
+    "queue",
+    "leasing",
+    "locking",
+    "multi-tenant",
+    "agents",
+    "claude-code",
+    "cli"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/tsingletaryTT/tt-gozer"
+    }
+  ],
+  "hardware": [
+    "blackhole",
+    "quietbox",
+    "galaxy"
+  ],
+  "author": "tsingletaryTT",
+  "language": "Python",
+  "license": "Apache-2.0",
+  "added_at": "2026-08-19"
+}

--- a/entries/games-demos/tt-bio-demo.json
+++ b/entries/games-demos/tt-bio-demo.json
@@ -1,0 +1,43 @@
+{
+  "id": "tt-bio-demo",
+  "name": "tt-bio-demo",
+  "description": "A turnkey conference-booth demo for tt-bio: watch a protein condense out of noise into its folded structure in real time, computed on the Blackhole chips a few feet away. Native GTK4 and OpenGL, with a cartoon renderer, live per-residue confidence colouring, a Tensix core grid, and a 2×2 quad view running four independent folds on four chips at once.",
+  "affiliation": "affiliated",
+  "categories": [
+    "games-demos",
+    "ai-models"
+  ],
+  "tags": [
+    "demo",
+    "protein-folding",
+    "boltz",
+    "drug-discovery",
+    "biology",
+    "visualization",
+    "gtk4",
+    "opengl",
+    "multi-card"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/tsingletaryTT/tt-bio-demo"
+    },
+    {
+      "type": "website",
+      "url": "https://tsingletarytt.github.io/tt-bio-demo/"
+    }
+  ],
+  "hardware": [
+    "blackhole",
+    "quietbox"
+  ],
+  "related": [
+    "tt-bio"
+  ],
+  "featured": true,
+  "author": "tsingletaryTT",
+  "language": "Python",
+  "license": "Apache-2.0",
+  "added_at": "2026-08-19"
+}

--- a/scripts/fetch_planet_feeds.py
+++ b/scripts/fetch_planet_feeds.py
@@ -313,13 +313,20 @@ def fetch_community_feed(feed: dict, known_urls: set) -> list:
         # CDATA or escaped HTML, not parsed children) tests false and an `or`
         # chain skips straight past it to the next candidate. That silently
         # emptied the description of every Atom item the fetcher wrote.
-        summary_el = None
+        #
+        # itertext(), not .text: Atom permits type="xhtml", where the body is a
+        # parsed <div> child rather than escaped markup, so .text is only the
+        # whitespace in front of it. itertext() flattens child text and tails,
+        # and for the escaped-HTML/CDATA case returns what .text returned.
+        raw = ""
         for tag in (f"{{{NS_ATOM}}}summary", f"{{{NS_ATOM}}}content", "description"):
             found = entry.find(tag)
-            if found is not None and (found.text or "").strip():
-                summary_el = found
+            if found is None:
+                continue
+            text = "".join(found.itertext())
+            if text.strip():
+                raw = text
                 break
-        raw = summary_el.text if summary_el is not None else ""
         desc = truncate(strip_html(raw))
         date_str = iso_to_date(published)
         items.append({

--- a/scripts/fetch_planet_feeds.py
+++ b/scripts/fetch_planet_feeds.py
@@ -67,6 +67,11 @@ COMMUNITY_FEEDS = [
     # entries). Re-add them here only if they ever ship a real feed.
     # Eric Zietlow (DevRel) — dev.to serves per-author RSS at /feed/<user>.
     {"name": "dev.to/mando222","url": "https://dev.to/feed/mando222",              "affiliation": "affiliated", "trusted": True},
+    # Taylor Singletary (DevRel) — Jekyll site, feed advertised via autodiscovery
+    # at /feed.xml. The feed carries only the /writing posts, which are all
+    # Tenstorrent engineering write-ups, so items land approved. If the writing
+    # ever broadens past TT work, flip trusted to False so it gets reviewed.
+    {"name": "tsingletarytt.github.io", "url": "https://tsingletarytt.github.io/feed.xml", "affiliation": "affiliated", "trusted": True},
 ]
 CONNPASS_FEEDS = [
     # Connpass serves group feeds at /ja.atom (there is no /feed.atom — it 404s).
@@ -302,9 +307,18 @@ def fetch_community_feed(feed: dict, known_urls: set) -> list:
         url = url.strip()
         if not url or url in known_urls:
             continue
-        summary_el = (entry.find(f"{{{NS_ATOM}}}summary") or
-                      entry.find(f"{{{NS_ATOM}}}content") or
-                      entry.find("description"))
+        # Explicit `is not None` per candidate, NOT an `or` chain: an
+        # ElementTree element is falsy when it has no child elements, so a
+        # text-only <summary>/<content> (the normal case — the post body is
+        # CDATA or escaped HTML, not parsed children) tests false and an `or`
+        # chain skips straight past it to the next candidate. That silently
+        # emptied the description of every Atom item the fetcher wrote.
+        summary_el = None
+        for tag in (f"{{{NS_ATOM}}}summary", f"{{{NS_ATOM}}}content", "description"):
+            found = entry.find(tag)
+            if found is not None and (found.text or "").strip():
+                summary_el = found
+                break
         raw = summary_el.text if summary_el is not None else ""
         desc = truncate(strip_html(raw))
         date_str = iso_to_date(published)

--- a/src/_data/planet_feeds.json
+++ b/src/_data/planet_feeds.json
@@ -2016,6 +2016,20 @@
     "affiliation": "official"
   },
   {
+    "type": "article",
+    "source": "tsingletarytt.github.io",
+    "approved": true,
+    "title": "AnimateDiff on Tenstorrent Hardware: The Full Story",
+    "url": "https://tsingletarytt.github.io/writing/2026/06/23/animatediff-on-tt-hardware-the-full-story/",
+    "description": "From wrong architecture to working video on Blackhole P300C — a complete account of bringing AnimateDiff to TT hardware: what broke, what we tried, what the hardware forced us to do differently, and what it looks like now.",
+    "date": "2026-06-23",
+    "dateISO": "2026-06-23T00:00:00Z",
+    "label": "tsingletarytt.github.io",
+    "projectName": "tsingletarytt.github.io",
+    "projectId": null,
+    "affiliation": "affiliated"
+  },
+  {
     "type": "release",
     "source": "github",
     "approved": true,

--- a/tests/test_fetch_planet_feeds.py
+++ b/tests/test_fetch_planet_feeds.py
@@ -213,6 +213,39 @@ def test_community_feed_skips_an_empty_summary_for_content(monkeypatch):
     assert [i["description"] for i in items] == ["Body text."]
 
 
+def test_community_feed_reads_atom_xhtml_content(monkeypatch):
+    """type="xhtml" bodies are parsed children, not escaped markup, so the
+    element's own .text is just the whitespace before the <div> — the text has
+    to be gathered from the children."""
+    items = _fetch_xml(monkeypatch, _atom("""
+      <entry>
+        <title>A post</title>
+        <link href="https://example.com/a" />
+        <published>2026-06-23T00:00:00-07:00</published>
+        <content type="xhtml">
+          <div xmlns="http://www.w3.org/1999/xhtml">
+            <p>Body text.</p>
+          </div>
+        </content>
+      </entry>"""))
+
+    assert [i["description"] for i in items] == ["Body text."]
+
+
+def test_community_feed_keeps_text_around_inline_markup(monkeypatch):
+    """Text after a nested element is that element's tail — dropping it would
+    truncate the summary at the first bit of inline markup."""
+    items = _fetch_xml(monkeypatch, _atom("""
+      <entry>
+        <title>A post</title>
+        <link href="https://example.com/a" />
+        <published>2026-06-23T00:00:00-07:00</published>
+        <summary>Before <b>middle</b> after.</summary>
+      </entry>"""))
+
+    assert [i["description"] for i in items] == ["Before middle after."]
+
+
 def test_community_feed_keeps_an_rss_description(monkeypatch):
     items = _fetch_xml(monkeypatch, """<rss><channel>
       <item>

--- a/tests/test_fetch_planet_feeds.py
+++ b/tests/test_fetch_planet_feeds.py
@@ -151,3 +151,92 @@ def test_merge_items_sorts_newest_first():
     merged = fpf.merge_items(existing, new, set())
 
     assert [i["url"] for i in merged] == ["https://example.com/new", "https://example.com/old"]
+
+
+# ── fetch_community_feed: Atom descriptions survive the parse ────────────────
+#
+# An ElementTree element is falsy when it has no *child* elements, and a feed's
+# <summary>/<content> is text (CDATA or escaped HTML), not children. The old
+# `find(summary) or find(content) or find("description")` chain therefore
+# skipped past the element it had just found and returned the final None, so
+# every Atom item the fetcher wrote landed with description "". RSS was
+# unaffected: its <description> is last in the chain, and `or` returns the last
+# operand regardless of truthiness.
+
+def _atom(body: str) -> str:
+    return f'<feed xmlns="{fpf.NS_ATOM}">{body}</feed>'
+
+
+def _fetch_xml(monkeypatch, xml: str, trusted: bool = True) -> list:
+    monkeypatch.setattr(fpf, "_get", lambda url, timeout=12: xml.encode())
+    feed = {"name": "example.com", "url": "https://example.com/atom.xml",
+            "affiliation": "community", "trusted": trusted}
+    return fpf.fetch_community_feed(feed, set())
+
+
+def test_community_feed_keeps_an_atom_summary(monkeypatch):
+    items = _fetch_xml(monkeypatch, _atom("""
+      <entry>
+        <title>A post</title>
+        <link href="https://example.com/a" />
+        <published>2026-06-23T00:00:00-07:00</published>
+        <summary>What the post is about.</summary>
+      </entry>"""))
+
+    assert [i["description"] for i in items] == ["What the post is about."]
+
+
+def test_community_feed_falls_back_to_atom_content(monkeypatch):
+    """No <summary> at all — the post body is the only description available."""
+    items = _fetch_xml(monkeypatch, _atom("""
+      <entry>
+        <title>A post</title>
+        <link href="https://example.com/a" />
+        <published>2026-06-23T00:00:00-07:00</published>
+        <content type="html">&lt;p&gt;Body text.&lt;/p&gt;</content>
+      </entry>"""))
+
+    assert [i["description"] for i in items] == ["Body text."]
+
+
+def test_community_feed_skips_an_empty_summary_for_content(monkeypatch):
+    """An empty <summary> must not shadow a <content> that has real text."""
+    items = _fetch_xml(monkeypatch, _atom("""
+      <entry>
+        <title>A post</title>
+        <link href="https://example.com/a" />
+        <published>2026-06-23T00:00:00-07:00</published>
+        <summary>   </summary>
+        <content type="html">&lt;p&gt;Body text.&lt;/p&gt;</content>
+      </entry>"""))
+
+    assert [i["description"] for i in items] == ["Body text."]
+
+
+def test_community_feed_keeps_an_rss_description(monkeypatch):
+    items = _fetch_xml(monkeypatch, """<rss><channel>
+      <item>
+        <title>A post</title>
+        <link>https://example.com/a</link>
+        <pubDate>Tue, 23 Jun 2026 00:00:00 +0000</pubDate>
+        <description>What the post is about.</description>
+      </item>
+    </channel></rss>""")
+
+    assert [i["description"] for i in items] == ["What the post is about."]
+
+
+def test_community_feed_carries_source_date_and_approval(monkeypatch):
+    """The published date is preserved, so a back-dated post files under the
+    month it was written rather than the day it was fetched."""
+    items = _fetch_xml(monkeypatch, _atom("""
+      <entry>
+        <title>A post</title>
+        <link href="https://example.com/a" />
+        <published>2026-06-23T00:00:00-07:00</published>
+        <summary>Summary.</summary>
+      </entry>"""), trusted=False)
+
+    assert items[0]["date"] == "2026-06-23"
+    assert items[0]["dateISO"] == "2026-06-23T00:00:00Z"
+    assert items[0]["approved"] is False


### PR DESCRIPTION
feat: add tt-bio-demo, tt-gozer and tt-demo-maker; pull tsingletarytt.github.io into the planet

## Entries

| Entry | Categories | Notes |
|---|---|---|
| **tt-bio-demo** | games-demos, ai-models | Turnkey conference-booth demo for tt-bio — GTK4/OpenGL protein folding on Blackhole, 2×2 quad view running four independent folds on four chips. `featured`. |
| **tt-gozer** | dev-tools, hw-system | Cooperative chip leasing so several agents (Claude Code sessions, aider, cron jobs) can share one box without corrupting each other's runs; the kernel's view of the devices is the tiebreaker. |
| **tt-demo-maker** | dev-tools | Rust-orchestrated toolkit for authoring demo recordings and draft posts from any project. Related to tt-toplike, which its shipped demos record. |

All three are personal repos of a Tenstorrent employee, so `affiliated`. Descriptions are drawn from each README rather than the one-line GitHub blurb. Hardware fields list only what each README actually claims.

**tt-bio-demo ↔ tt-bio** is linked in both directions — `related` chips render only on the entry that declares them, so the reciprocal was added to `entries/ai-models/tt-bio.json`.

## Planet

Registered `tsingletarytt.github.io` in `COMMUNITY_FEEDS` (affiliated, trusted) so future posts arrive approved without hand-editing, and added its one existing post — **"AnimateDiff on Tenstorrent Hardware: The Full Story"** — which files under **Jun 23 2026**, its publish date rather than the day it was fetched.

The item was written by calling the fetcher's own `fetch_community_feed` + `merge_items` and its exact write path, not a full `main()` run — a full run would have swept in unrelated new YouTube/Reddit/arXiv items and buried this change. The row is byte-identical in shape to what the nightly run produces, so tonight's CI is a no-op for it.

## Fix: every Atom item was losing its description

`fetch_community_feed` picked its summary with:

```python
summary_el = (entry.find(f"{{{NS_ATOM}}}summary") or
              entry.find(f"{{{NS_ATOM}}}content") or
              entry.find("description"))
```

An ElementTree element is falsy when it has no **child** elements, and a feed's `<summary>`/`<content>` is *text* (CDATA or escaped HTML), not children. So the chain tested the element it had just found as false and fell through to the final `None`. Every Atom item the fetcher ever wrote landed with `description: ""` — visible in the existing data: three clehaxze.tw items have empty descriptions, and the three with prose were written by hand. RSS was unaffected, because its `<description>` is last in the chain and `or` returns the last operand regardless of truthiness.

Replaced with an explicit per-candidate `is not None` + non-empty-text check (so an empty `<summary>` no longer shadows a `<content>` that has real text), plus five regression tests. The new post now carries its real summary instead of `""`.

Pre-existing empty descriptions are left alone — the fix only affects newly fetched items, and backfilling those needs a re-fetch or hand-written summaries.

## Verification

- `python3 -m pytest tests -q` → **145 passed** (was 140)
- `python3 scripts/validate.py` → **all 155 entries valid**
- `npm run build` + every JS suite passes, including `test_entry_pages.js` (154 static entry pages)
- Built `_site/planet/index.html` shows the new card as `Jun 23, 2026` · `📝 article` · `affiliated`, adjacent to the other June 23 items

## Notes for review

- The post URL is deliberately **not** added as an `article` link on the `tt-animatediff` entry: entry-derived planet cards are processed first and claim their URLs, so that would have suppressed this standalone card and replaced it with one titled "tt-animatediff" dated by that entry's `added_at` (2026-06-03).
- `README.md` and `data.json` are untouched — they're generated at deploy, matching recent entry-add commits.
- The feed's comment notes to flip `trusted` to `False` if the writing ever broadens past Tenstorrent work, mirroring the clehaxze.tw rationale.
