### PR TITLE
Add tt-finetune; lower SPARSE_LIMIT to 70 and crawl bare compare links

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -106,10 +106,26 @@ filtered before the model is ever called:
 
 - already present in `planet_feeds.json` (deduplicated by URL)
 - pre-release tags — `dev`, `rc`, `alpha`, `beta`, `qa`, CI experiment tags
-- bodies under `SPARSE_LIMIT` (120 chars) in `scripts/summarize_releases.py`
+- bodies under `SPARSE_LIMIT` (70 chars) in `scripts/summarize_releases.py`
 
 A repo whose releases carry empty bodies will never produce feed items. That is
 intended: summarizing "Bug fixes." yields nothing worth publishing.
+
+**A thin body is not always the end of the road.** Before the gate runs, two
+paths go looking for the real content the body points at:
+
+| Body looks like | What is summarized instead |
+|---|---|
+| mentions `CHANGELOG.md` (`body_defers_to_changelog`) | that version's changelog section |
+| is *only* `**Full Changelog**: <compare url>` (`body_defers_to_compare`) | the commit subjects from the compare view, merges dropped and duplicates collapsed, capped at `COMPARE_COMMIT_CAP` |
+
+The compare crawl exists because a bare compare link is ~73 characters of pure
+URL — it clears `SPARSE_LIMIT` while telling the model nothing, so the summary
+would have to be invented. Both paths are best-effort: if the changelog section
+or the compare API cannot be reached, the release falls back to the ordinary
+gate and is skipped rather than published from nothing. A body that carries real
+notes *alongside* a compare link (GitHub's generated "What's Changed" list) is
+summarized as-is and never triggers the crawl.
 
 **Metadata gaps are logged but do not fail the run.** `fetch_github_meta.py`
 prints `WARN <repo>: HTTP 404` for repos it cannot read — private, renamed, or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,3 +97,69 @@ QuietBox-only; the package supports Wormhole and Blackhole P150x4/P300x2).
 emulate a mobile viewport — it lays out at ~800px and crops the image to 430. A screenshot
 that looks like right-edge clipping at "mobile width" is usually that artifact, not a CSS
 overflow bug. Verify by shooting at 800px and comparing.
+
+### 2026-09-04 — tt-finetune entry, and SPARSE_LIMIT 120 → 70
+
+Prompt: *"Let's add https://github.com/danielisraeli2409-jpg/tt-finetune to the awesome list
+and include its latest release in the planet feed"*, then *"ok let's add it to make the
+complete card. let's lower our sparse limit to 70 chars and see how ti goes?"*
+
+**Entry.** `community` — personal account, no TT org, and `employee_search` finds no
+matching Tenstorrent employee (Jeremy introduced it in `#devrel-private` as a community
+project). `language: Python` despite GitHub reporting C++ by byte count: the C++ is the
+bundled TT-XLA/TT-Metal runtime under `tt_finetune/_resident_bundles`, while every source
+directory is Python. No `packages` — the README states outright it does not claim PyPI
+publication, and the wheel installs from a release URL.
+
+`github_meta.json` was updated by importing `fetch_github_meta`'s functions for this one
+repo rather than running `main()`, which rewrites all 119 entries and would have buried
+the change in unrelated star churn.
+
+**Planet items written by hand.** No `ANTHROPIC_API_KEY`/`FOUNDRY_API_KEY` in the local
+environment, so `summarize_releases.py` cannot run here. The three items were written to
+the exact schema `main()` emits, following `summarize-release.prompt.yml`. Grouping then
+did its job at render time: v0.2.0 (8/26), v0.2.1 (8/28), demo (8/29) chain into one card,
+"3 releases · Aug 26 – Aug 29".
+
+**SPARSE_LIMIT 120 → 70.** Measured rather than guessed: of the releases in
+`github_meta.json` that the gate is the *only* thing blocking (11, after pre-release and
+rename filters), five sit in [70, 120) and six have literally empty bodies. Nothing at all
+falls in 1–69 in the current window, so 70 is a clean place to stand.
+
+**The 70-char gate exposed a hole, and the fix went a different way than proposed.**
+`zk4x/zyx v0.14.0` is 73 chars and its entire body is `**Full Changelog**:
+https://github.com/zk4x/zyx/compare/v0.13.0...v0.14.0` — GitHub's auto-generated link and
+nothing else. It clears 70 *only because the URL is long*. I proposed stripping URLs
+before measuring; Taylor asked instead: *"When we see this Full Changelog and URL line
+like this, can we ask our script/agent to crawl it and summarize from that?"* — which is
+the better answer, because it turns a skip into a real item.
+
+`body_defers_to_compare` + `parse_compare_url` + `fetch_compare_log` follow the link and
+summarize the commit subjects. Deliberately mirrors the existing
+`body_defers_to_changelog` → `fetch_changelog_section` pattern, and runs *after* it, since
+curated notes beat a raw commit log whenever both exist.
+
+Key decisions:
+* **Only fires when the link is the *whole* body.** GitHub's generated "What's Changed"
+  notes also end with a Full Changelog line, and those already have content — the check
+  strips the pointer line and crawls only if what remains is itself sparse. Verified
+  against all five newly-admitted releases: only zyx v0.14.0 crawls.
+* **Merge commits dropped, duplicate subjects collapsed.** Working branches restate the
+  same subject repeatedly — zyx v0.14.0 says "work on multi head attention" twice.
+* **The sparse gate is applied to the commit subjects alone, before the framing header is
+  added.** The header is ~200 chars, so gating the finished string would carry a
+  single-`bump`-commit release straight through. This is the one non-obvious bit; there is
+  a test pinning it.
+* **The header tells the model these are raw commit messages, not curated notes.** Left
+  implicit, summaries of a commit log drift into describing it as a polished release.
+* Best-effort throughout: any API failure returns None and the release falls back to being
+  skipped, never published from nothing.
+
+Result on the real release: 73 chars of URL → 835 chars of genuine commit log. The
+subjects are rough ("deinit", "licence", "cleanup") so the summary will be modest — but
+sourced rather than invented, which was the whole point.
+
+**Gotcha while writing the tests:** three of my own commit subjects in the
+merge-filtering test summed to 67 chars, so it failed on the sparse gate rather than on
+merge filtering. When writing fixtures for this path, keep subject text comfortably over
+`SPARSE_LIMIT` unless sparseness is what you are testing.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ A curated directory of projects, tools, models, and research for Tenstorrent har
 
 ## 🤖 AI & Models
 
+- **[tt-finetune](https://github.com/danielisraeli2409-jpg/tt-finetune)** ![community](https://img.shields.io/badge/community-27AE60?style=flat-square)
+  by [@danielisraeli2409-jpg](https://github.com/danielisraeli2409-jpg) — Parameter-efficient fine-tuning — LoRA, rsLoRA, LoRA+, DoRA, and IA3 — on a single Blackhole P150a, behind a Hugging Face/PEFT-style trainer API. Ships as a self-contained Linux wheel bundling the TT-XLA/PJRT plugin, TTNN, and TT-Metal user-space libraries, so no source checkout, Docker, or PYTHONPATH setup is required. Includes a static planner that reports memory admission before you compile, deterministic checkpoint/resume, and standard PEFT adapter export.
+  [📦 repo](https://github.com/danielisraeli2409-jpg/tt-finetune)
+
 - **[tt-model-bringup](https://github.com/aweditya/tt-model-bringup)** ![community](https://img.shields.io/badge/community-27AE60?style=flat-square)
   by [@aweditya](https://github.com/aweditya) — Direct TT-Metal bringup of modern open-weight LLMs on Blackhole P150 — hand-written compute graphs with no PJRT and no JAX. Covers Qwen3.6-27B, Qwen3.6-35B-A3B MoE, Gemma 4 12B, and Nemotron-3 Nano 30B-A3B, plus a zoo of single-chip Llama / Qwen2.5 / SmolLM ports, backed by custom fused `owned_*` kernels, a continuous-batching engine, an OpenAI-compatible HTTP server, and a wiki documenting each design decision.
   [📦 repo](https://github.com/aweditya/tt-model-bringup) · [📖 HANDOFF.md — current perf and production paths](https://github.com/aweditya/tt-model-bringup/blob/main/HANDOFF.md)

--- a/entries/ai-models/tt-finetune.json
+++ b/entries/ai-models/tt-finetune.json
@@ -1,0 +1,29 @@
+{
+  "id": "tt-finetune",
+  "name": "tt-finetune",
+  "description": "Parameter-efficient fine-tuning — LoRA, rsLoRA, LoRA+, DoRA, and IA3 — on a single Blackhole P150a, behind a Hugging Face/PEFT-style trainer API. Ships as a self-contained Linux wheel bundling the TT-XLA/PJRT plugin, TTNN, and TT-Metal user-space libraries, so no source checkout, Docker, or PYTHONPATH setup is required. Includes a static planner that reports memory admission before you compile, deterministic checkpoint/resume, and standard PEFT adapter export.",
+  "affiliation": "community",
+  "categories": [
+    "ai-models"
+  ],
+  "tags": [
+    "fine-tuning",
+    "training",
+    "lora",
+    "peft",
+    "blackhole"
+  ],
+  "links": [
+    {
+      "type": "repo",
+      "url": "https://github.com/danielisraeli2409-jpg/tt-finetune"
+    }
+  ],
+  "hardware": [
+    "blackhole"
+  ],
+  "author": "danielisraeli2409-jpg",
+  "language": "Python",
+  "license": "Apache-2.0",
+  "added_at": "2026-09-04"
+}

--- a/scripts/fetch_github_meta.py
+++ b/scripts/fetch_github_meta.py
@@ -124,16 +124,32 @@ def fetch_releases(repo: str, per_page: int = 5) -> list:
         tagName, name, publishedAt, url, prerelease, assets
     Draft releases are skipped; pre-releases are included (caller can filter).
     Returns an empty list on any error so a single bad repo never aborts the run.
+
+    The list is sorted newest-published first. This is not cosmetic:
+    src/_data/entries.js resolves latestStableRelease with releases.find(...),
+    which takes the first match in array order and so assumes newest-first.
+    GitHub's list-releases endpoint sorts by *created_at*, which is the tag's
+    date — a release tagged from an older commit but published later arrives
+    out of order and silently changes which release the site calls "latest".
+    tt-finetune's demo-2026-08-29 (same created_at as v0.2.1, published a day
+    later) is the case that surfaced it. Sorting here makes the invariant the
+    data layer documents hold for every repo on every run, rather than by luck
+    of how a maintainer happened to cut their tags.
     """
     try:
         url = f"https://api.github.com/repos/{repo}/releases?per_page={per_page}"
         with urllib.request.urlopen(_request(url), timeout=10) as r:
             releases = json.loads(r.read())
-            return [
+            parsed = [
                 _parse_release(rel)
                 for rel in releases
                 if not rel.get("draft", False)
             ]
+            # `or ""` keeps a null published_at (possible on a draft just
+            # promoted to a release) sorting last instead of raising and
+            # costing us the repo's entire release list.
+            parsed.sort(key=lambda r: r.get("publishedAt") or "", reverse=True)
+            return parsed
     except urllib.error.HTTPError as e:
         print(f"  WARN {repo} releases: HTTP {e.code}", file=sys.stderr)
     except Exception as e:

--- a/scripts/summarize_releases.py
+++ b/scripts/summarize_releases.py
@@ -41,10 +41,13 @@ PR_BODY_OUT = Path(os.environ.get("PR_BODY_PATH") or (ROOT / "pr-body.md"))
 PR_BODY_TEMPLATE = ROOT / ".github" / "pr-templates" / "github-metadata.md"
 
 MODEL = "claude-haiku-4-5-20251001"  # Anthropic-direct default; see llm_client
-SPARSE_LIMIT = 120  # characters; bodies shorter than this are skipped.
-# Set to 120 (down from 150) so terse-but-substantive notes — a few real
-# bullet points, e.g. ttsim v1.8.4's ~134-char changelog — still get
-# summarized, while one-liners like "Bug fixes." remain filtered out.
+SPARSE_LIMIT = 70  # characters; bodies shorter than this are skipped.
+# History: 150 → 120 (terse-but-substantive notes, e.g. ttsim v1.8.4's ~134-char
+# changelog, were being dropped) → 70. The 70 step was prompted by tt-finetune's
+# 86-char "Blackhole P150a Demo" release: a body can be a single sentence and
+# still be the only announcement a real artifact ever gets. One-liners like
+# "Bug fixes." (10 chars) stay filtered, but the margin above them is now thin —
+# if generic blurbs start showing up on the planet, this is the knob.
 
 TOKEN = os.environ.get("ANTHROPIC_API_KEY", "")     # LLM calls when SUMMARY_PROVIDER=anthropic
 GH_TOKEN = os.environ.get("GITHUB_TOKEN", "")       # GitHub REST API (release bodies, changelogs)
@@ -183,6 +186,133 @@ def body_defers_to_changelog(body: str) -> bool:
     section instead.
     """
     return bool(_DEFERS_RE.search(body or ""))
+
+
+# ── Bodies that are nothing but GitHub's "Full Changelog" link ───────────────
+# GitHub appends a "**Full Changelog**: <compare url>" line to auto-generated
+# release notes. When that line is the *whole* body, the release carries no
+# prose at all — and because a compare URL runs ~70 characters on its own, it
+# sails past SPARSE_LIMIT on URL length while giving the model nothing to work
+# from but the version numbers. zyx v0.14.0 is exactly this: 73 characters, all
+# of them the link.
+#
+# Rather than publish an invented blurb or widen the gate, we follow the link
+# and summarize the commit subjects behind it. Same move as
+# body_defers_to_changelog: the body says where the changes are, so go there.
+# Commit subjects are rougher than curated notes — often lowercase, sometimes
+# telegraphic — but they are what actually changed, which is the property that
+# matters.
+
+# The compare URL as it appears in a body. The repo is captured so a link that
+# points at a *different* repo than the release still resolves correctly.
+_COMPARE_URL_RE = re.compile(
+    r"https://(?:www\.)?github\.com/([^/\s]+/[^/\s]+?)/compare/([^\s>)\]]+)", re.I
+)
+
+# A whole line that is just the "Full Changelog" pointer. Tolerates the bold
+# markers GitHub emits, an angle-bracket autolink, quoting, and a missing colon.
+_FULL_CHANGELOG_LINE_RE = re.compile(
+    r"^[ \t>*_-]*\**\s*full\s+changelog\s*\**\s*:?\s*<?"
+    r"(https://\S*?/compare/[^\s>)\]]+)>?[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# How many commit subjects to hand the model. The compare API returns at most
+# 250 commits per response; 50 is well inside that and already more than enough
+# for a 2-5 sentence summary — past that the list is noise the model pays for.
+COMPARE_COMMIT_CAP = 50
+
+
+def body_defers_to_compare(body: str) -> str | None:
+    """Return the compare URL when a body is *only* a "Full Changelog" pointer.
+
+    Returns None when the body has real notes alongside the link — GitHub's
+    generated "What's Changed" list is the common case, and there is already
+    something worth summarizing there, so crawling would be wasted work.
+
+    Unlike body_defers_to_changelog this returns the URL rather than a bool,
+    because the caller's very next need is the link itself.
+    """
+    m = _FULL_CHANGELOG_LINE_RE.search(body or "")
+    if not m:
+        return None
+    remainder = _FULL_CHANGELOG_LINE_RE.sub("", body).strip()
+    if not is_sparse(remainder):
+        return None
+    return m.group(1)
+
+
+def parse_compare_url(url: str) -> tuple[str, str] | None:
+    """Split a compare URL into ``(repo, spec)``, or None if it is not one.
+
+    ``spec`` is GitHub's basehead expression (``v0.13.0...v0.14.0``) and is
+    passed through to the API untouched, so fork comparisons (``owner:branch``)
+    keep working.
+    """
+    m = _COMPARE_URL_RE.match((url or "").strip())
+    if not m:
+        return None
+    repo = m.group(1)
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    return repo, m.group(2)
+
+
+def fetch_compare_log(repo: str, spec: str, cap: int = COMPARE_COMMIT_CAP) -> str | None:
+    """Fetch a compare view and render its commit subjects for summarization.
+
+    Returns None — and the caller falls back to skipping the release — on any
+    API failure, or when what comes back is too thin to be worth a model call.
+
+    Merge commits are dropped (they describe branch topology, not changes) and
+    repeated subjects collapse to one, because working branches restate the
+    same subject across several commits: zyx v0.14.0 carries "work on multi
+    head attention" twice.
+    """
+    url = f"https://api.github.com/repos/{repo}/compare/{spec}"
+    try:
+        with urllib.request.urlopen(_gh_request(url), timeout=10) as r:
+            data = json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        print(f"  WARN fetch_compare_log {repo} {spec}: HTTP {e.code}", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"  WARN fetch_compare_log {repo} {spec}: {e}", file=sys.stderr)
+        return None
+
+    subjects, seen = [], set()
+    for c in data.get("commits") or []:
+        if len(c.get("parents") or []) > 1:
+            continue
+        subject = ((c.get("commit") or {}).get("message") or "").split("\n")[0].strip()
+        if not subject:
+            continue
+        key = subject.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        subjects.append(subject)
+
+    if not subjects:
+        return None
+
+    shown = subjects[:cap]
+    # Gate on the subjects alone, before the framing text is bolted on. The
+    # header is ~150 characters by itself, so checking the finished string
+    # would carry a single "bump" commit straight past SPARSE_LIMIT.
+    if is_sparse("\n".join(shown)):
+        return None
+
+    total = data.get("total_commits", len(subjects))
+    # Tell the model plainly what it is reading. Left implicit, summaries of a
+    # commit log drift into describing it as though it were a curated release.
+    header = (f"The release notes contain only an auto-generated compare link, so what "
+              f"follows are the commit subjects in {spec} ({total} commits in total). "
+              f"They are raw commit messages, not curated release notes.")
+    lines = "\n".join(f"- {s}" for s in shown)
+    footer = (f"\n\n(showing the first {len(shown)} of {len(subjects)} non-merge commits)"
+              if len(shown) < len(subjects) else "")
+    return f"{header}\n\n{lines}{footer}"
 
 
 def extract_changelog_section(changelog_text: str, tag: str, date: str | None = None) -> str | None:
@@ -474,6 +604,21 @@ def main(argv: list | None = None):
                     content = section
                     print(f"  CHANGELOG {repo}@{tag}: summarizing changelog section "
                           f"({len(section.strip())} chars) — body defers to it")
+
+            # Other repos publish a body that is nothing but GitHub's
+            # auto-generated "Full Changelog" compare link. There is no prose to
+            # summarize at all, so follow the link and use the commit subjects.
+            # `content is body` means no better source has been found yet —
+            # curated changelog notes win over a raw commit log when both exist.
+            if content is body and (compare_url := body_defers_to_compare(body)):
+                parsed = parse_compare_url(compare_url)
+                if parsed:
+                    compare_repo, spec = parsed
+                    log = fetch_compare_log(compare_repo, spec)
+                    if log:
+                        content = log
+                        print(f"  COMPARE {repo}@{tag}: summarizing the commit log for "
+                              f"{spec} — body is only a compare link")
 
             # Quality-gate whatever content we actually plan to summarize.
             if is_sparse(content):

--- a/scripts/summarize_releases.py
+++ b/scripts/summarize_releases.py
@@ -245,17 +245,33 @@ def body_defers_to_compare(body: str) -> str | None:
 def parse_compare_url(url: str) -> tuple[str, str] | None:
     """Split a compare URL into ``(repo, spec)``, or None if it is not one.
 
-    ``spec`` is GitHub's basehead expression (``v0.13.0...v0.14.0``) and is
-    passed through to the API untouched, so fork comparisons (``owner:branch``)
-    keep working.
+    ``spec`` is GitHub's basehead expression (``v0.13.0...v0.14.0``), taken
+    verbatim from the URL path so fork and branch comparisons
+    (``main...fork:feature/x``) survive intact — the API accepts them as-is,
+    and because the spec comes out of a URL path it is already percent-encoded
+    where it needs to be. Re-quoting it here would double-encode any ``%2F``.
+
+    The query string and fragment are dropped first. Compare links get shared
+    straight from the browser's URL bar, carrying view state such as
+    ``?diff=split`` or a ``#diff-<sha>`` anchor; those describe the *page*, not
+    the basehead, and interpolating them into the API path yields a 404 — which
+    surfaces as a release quietly skipped rather than an error worth chasing.
     """
-    m = _COMPARE_URL_RE.match((url or "").strip())
+    cleaned = (url or "").strip().split("#", 1)[0].split("?", 1)[0]
+    m = _COMPARE_URL_RE.match(cleaned)
     if not m:
         return None
     repo = m.group(1)
     if repo.endswith(".git"):
         repo = repo[:-4]
-    return repo, m.group(2)
+    spec = m.group(2).rstrip("/")
+    # Release bodies are attacker-influenced: every repo owner in the list
+    # writes their own. Refuse a spec whose path segments could climb out of
+    # /compare/ and address some other API endpoint. The "..." basehead
+    # separator is not a path segment, so ordinary specs are unaffected.
+    if not spec or any(seg in (".", "..") for seg in spec.split("/")):
+        return None
+    return repo, spec
 
 
 def fetch_compare_log(repo: str, spec: str, cap: int = COMPARE_COMMIT_CAP) -> str | None:

--- a/scripts/summarize_releases.py
+++ b/scripts/summarize_releases.py
@@ -6,7 +6,12 @@
 
 For each release URL in github_meta.json not already in planet_feeds.json:
   - Fetches the release body from the GitHub API
-  - Skips if body is empty or under 120 characters
+  - Resolves what to actually summarize, in priority order:
+      1. the release body as written;
+      2. if the body defers to a changelog file, that version's section;
+      3. if the body is *only* a "Full Changelog" compare link, the commit
+         subjects from the compare view (see fetch_compare_log).
+  - Skips if the resolved content is empty or under SPARSE_LIMIT characters
   - Runs prompts/summarize-release.prompt.yml through llm_client (Claude on
     Microsoft Foundry by default; SUMMARY_PROVIDER=anthropic calls Anthropic
     direct. The former `github` GitHub Models path was retired 2026-07-30.)

--- a/src/_data/entries.js
+++ b/src/_data/entries.js
@@ -83,13 +83,22 @@ module.exports = function () {
     // "7.67.0-strength-49763" (version + branch word + run number) — GitHub
     // marks these non-prerelease, so only the tag shape identifies them.
     const PRE_RELEASE_TAG = /[.\-]dev[.\d]|[-.]rc\d+|[-.]alpha|[-.]beta|[-.]qa[\d.]|\d-[a-z]+-\d+$/i;
+    // A tag that actually names a version. Repos also cut dated, non-version
+    // tags for things that are not builds at all — tt-finetune publishes
+    // `demo-2026-08-29`, a screen recording, one day *after* v0.2.1. Those are
+    // real non-prerelease releases, so without this the newest-first list makes
+    // the site advertise a demo video as the project's latest stable release.
+    const VERSION_TAG = /\d+\.\d+/;
 
     if (Array.isArray(entry.releases) && entry.releases.length) {
       // Check both GitHub's prerelease flag AND the tag name — GitHub sometimes
       // marks dev/rc builds as non-prerelease, so the tag is the tiebreaker.
-      let stable = entry.releases.find(
-        r => !r.prerelease && !PRE_RELEASE_TAG.test(r.tagName)
-      );
+      const isStableCandidate = r => !r.prerelease && !PRE_RELEASE_TAG.test(r.tagName);
+      // Prefer a version-shaped tag, but fall back to the newest plain
+      // candidate: some repos never tag a version at all (polaris ships
+      // `pre_perfmodel_merge`) and must keep their release callout.
+      let stable = entry.releases.find(r => isStableCandidate(r) && VERSION_TAG.test(r.tagName))
+        || entry.releases.find(isStableCandidate);
 
       if (!stable) {
         const allTagsAreDev = entry.releases.every(r => PRE_RELEASE_TAG.test(r.tagName));

--- a/src/_data/github_meta.json
+++ b/src/_data/github_meta.json
@@ -5063,5 +5063,46 @@
         "prerelease": false
       }
     ]
+  },
+  "https://github.com/danielisraeli2409-jpg/tt-finetune": {
+    "stars": 1,
+    "updatedAt": "2026-08-28T17:25:24Z",
+    "releases": [
+      {
+        "tagName": "v0.2.1",
+        "name": "tt-finetune v0.2.1",
+        "publishedAt": "2026-08-28T17:21:58Z",
+        "url": "https://github.com/danielisraeli2409-jpg/tt-finetune/releases/tag/v0.2.1",
+        "prerelease": false,
+        "assets": [
+          {
+            "name": "tt_finetune-0.2.1-cp312-cp312-linux_x86_64.whl",
+            "url": "https://github.com/danielisraeli2409-jpg/tt-finetune/releases/download/v0.2.1/tt_finetune-0.2.1-cp312-cp312-linux_x86_64.whl",
+            "size": 364636300
+          }
+        ]
+      },
+      {
+        "tagName": "demo-2026-08-29",
+        "name": "tt-finetune Blackhole P150a Demo",
+        "publishedAt": "2026-08-29T15:44:38Z",
+        "url": "https://github.com/danielisraeli2409-jpg/tt-finetune/releases/tag/demo-2026-08-29",
+        "prerelease": false
+      },
+      {
+        "tagName": "v0.2.0",
+        "name": "tt-finetune 0.2.0",
+        "publishedAt": "2026-08-26T07:14:15Z",
+        "url": "https://github.com/danielisraeli2409-jpg/tt-finetune/releases/tag/v0.2.0",
+        "prerelease": false,
+        "assets": [
+          {
+            "name": "tt_finetune-0.2.0-cp312-cp312-linux_x86_64.whl",
+            "url": "https://github.com/danielisraeli2409-jpg/tt-finetune/releases/download/v0.2.0/tt_finetune-0.2.0-cp312-cp312-linux_x86_64.whl",
+            "size": 374768845
+          }
+        ]
+      }
+    ]
   }
 }

--- a/src/_data/github_meta.json
+++ b/src/_data/github_meta.json
@@ -5069,6 +5069,13 @@
     "updatedAt": "2026-08-28T17:25:24Z",
     "releases": [
       {
+        "tagName": "demo-2026-08-29",
+        "name": "tt-finetune Blackhole P150a Demo",
+        "publishedAt": "2026-08-29T15:44:38Z",
+        "url": "https://github.com/danielisraeli2409-jpg/tt-finetune/releases/tag/demo-2026-08-29",
+        "prerelease": false
+      },
+      {
         "tagName": "v0.2.1",
         "name": "tt-finetune v0.2.1",
         "publishedAt": "2026-08-28T17:21:58Z",
@@ -5081,13 +5088,6 @@
             "size": 364636300
           }
         ]
-      },
-      {
-        "tagName": "demo-2026-08-29",
-        "name": "tt-finetune Blackhole P150a Demo",
-        "publishedAt": "2026-08-29T15:44:38Z",
-        "url": "https://github.com/danielisraeli2409-jpg/tt-finetune/releases/tag/demo-2026-08-29",
-        "prerelease": false
       },
       {
         "tagName": "v0.2.0",

--- a/src/_data/planet_feeds.json
+++ b/src/_data/planet_feeds.json
@@ -269,6 +269,20 @@
     "type": "release",
     "source": "github",
     "approved": true,
+    "title": "tt-finetune demo-2026-08-29",
+    "url": "https://github.com/danielisraeli2409-jpg/tt-finetune/releases/tag/demo-2026-08-29",
+    "description": "A short screen recording, attached as `demo_final.mp4`, showing real LoRA training run end to end on a Tenstorrent Blackhole P150a — the same single-card path the 0.2.x wheels install. Worth a look if you have been reading the geometry and admission claims and want to see what the loop actually looks like on silicon.",
+    "date": "2026-08-29",
+    "dateISO": "2026-08-29T15:44:38Z",
+    "label": "danielisraeli2409-jpg/tt-finetune",
+    "projectName": "tt-finetune",
+    "projectId": null,
+    "affiliation": "community"
+  },
+  {
+    "type": "release",
+    "source": "github",
+    "approved": true,
     "title": "tt-installer v3.6.0",
     "url": "https://github.com/tenstorrent/tt-installer/releases/tag/v3.6.0",
     "description": "The installer now supports [safe dry-run previews](https://github.com/tenstorrent/tt-installer/pull/153), letting you inspect what would be installed before committing—a practical win for validating setups in CI/CD or containerized environments. Along with that, firmware updates are [now disabled by default in container mode](https://github.com/tenstorrent/tt-installer/pull/157), sidestepping unexpected state changes when running inside Docker, plus improved test coverage to catch regressions in both modes.",
@@ -306,6 +320,20 @@
     "projectName": "tt-local-generator",
     "projectId": null,
     "affiliation": "official"
+  },
+  {
+    "type": "release",
+    "source": "github",
+    "approved": true,
+    "title": "tt-finetune v0.2.1",
+    "url": "https://github.com/danielisraeli2409-jpg/tt-finetune/releases/tag/v0.2.1",
+    "description": "Sparse-MoE models now train with dynamic selected-expert execution on device — no host-side token routing, and no evaluating every expert just to discard most of the results — which puts MoE fine-tuning on a single Blackhole P150a within reach. Alongside that, fused MQA, shared-expert MoE, irregular sequence geometry, and functional causal masks all picked up architecture-semantic corrections, so models that were quietly training on the wrong shapes now match reference behavior. The resident execution and compiler paths are more deterministic for qualified dense workloads, and the build was qualified from a clean wheel: device smoke, dense training, exact checkpoint resume, and PEFT export, reload, and continued training.",
+    "date": "2026-08-28",
+    "dateISO": "2026-08-28T17:21:58Z",
+    "label": "danielisraeli2409-jpg/tt-finetune",
+    "projectName": "tt-finetune",
+    "projectId": null,
+    "affiliation": "community"
   },
   {
     "type": "paper",
@@ -404,6 +432,20 @@
     "projectName": "tt-animatediff",
     "projectId": null,
     "affiliation": "official"
+  },
+  {
+    "type": "release",
+    "source": "github",
+    "approved": true,
+    "title": "tt-finetune v0.2.0",
+    "url": "https://github.com/danielisraeli2409-jpg/tt-finetune/releases/tag/v0.2.0",
+    "description": "The self-contained preview is complete: a geometry-aware measured autotuner, dynamic selected-expert sparse MoE, the full LoRA, rsLoRA, LoRA+, DoRA, and IA3 adapter set, and BF16 alongside qualified BF8/BF4 frozen-weight paths — all reachable without Docker, a source checkout, or PYTHONPATH wrangling, since the wheel carries TT-XLA/PJRT, TTNN, and the TT-Metal runtime and compiler with it. The planner accepted 19 of 19 dense and MoE geometry qualification cases and lands within 5% of the broader oracle across general cases, so the memory admission answer you get before compiling is worth trusting. Deterministic checkpoint/resume, PEFT export and reload, and data packing, bucketing, and prefetch round it out, with 598 owned regression tests and real P150a silicon qualification behind the build.",
+    "date": "2026-08-26",
+    "dateISO": "2026-08-26T07:14:15Z",
+    "label": "danielisraeli2409-jpg/tt-finetune",
+    "projectName": "tt-finetune",
+    "projectId": null,
+    "affiliation": "community"
   },
   {
     "type": "release",

--- a/tests/test_data_files.js
+++ b/tests/test_data_files.js
@@ -38,6 +38,34 @@ Module._load = function (request, parent, isMain) {
         stars: 3,
         updatedAt: "2026-01-01T00:00:00Z",
       },
+      // Newest release is a dated demo tag carrying no version number. It is a
+      // genuine non-prerelease, so a plain "newest non-prerelease wins" rule
+      // would advertise a screen recording as the project's latest stable
+      // build. The version-shaped tag has to win. (Real case: tt-finetune's
+      // demo-2026-08-29, published a day after v0.2.1.)
+      "https://github.com/test/demotag": {
+        stars: 1,
+        updatedAt: "2026-08-29T00:00:00Z",
+        releases: [
+          { tagName: "demo-2026-08-29", name: "Demo", publishedAt: "2026-08-29T15:44:38Z",
+            url: "https://github.com/test/demotag/releases/tag/demo-2026-08-29", prerelease: false },
+          { tagName: "v0.2.1", name: "v0.2.1", publishedAt: "2026-08-28T17:21:58Z",
+            url: "https://github.com/test/demotag/releases/tag/v0.2.1", prerelease: false },
+          { tagName: "v0.2.0", name: "v0.2.0", publishedAt: "2026-08-26T07:14:15Z",
+            url: "https://github.com/test/demotag/releases/tag/v0.2.0", prerelease: false },
+        ],
+      },
+      // No release here carries a version number at all — polaris ships tags
+      // like "pre_perfmodel_merge". The newest non-prerelease must still win,
+      // or the entry silently loses its release callout.
+      "https://github.com/test/noversion": {
+        stars: 2,
+        updatedAt: "2026-01-01T00:00:00Z",
+        releases: [
+          { tagName: "pre_perfmodel_merge", name: "pre merge", publishedAt: "2026-06-01T00:00:00Z",
+            url: "https://github.com/test/noversion/releases/tag/pre_perfmodel_merge", prerelease: false },
+        ],
+      },
     };
   }
   return _origLoad.apply(this, arguments);
@@ -51,6 +79,10 @@ const testEntries = [
     links: [{ type: "repo", url: "https://github.com/test/preonly" }] },
   { id: "entry-noreleases", name: "No Releases Project", affiliation: "official",
     links: [{ type: "repo", url: "https://github.com/test/noreleases" }] },
+  { id: "entry-demotag", name: "Demo Tag Project", affiliation: "community",
+    links: [{ type: "repo", url: "https://github.com/test/demotag" }] },
+  { id: "entry-noversion", name: "No Version Project", affiliation: "official",
+    links: [{ type: "repo", url: "https://github.com/test/noversion" }] },
 ];
 
 // Patch fs.readdirSync and fs.readFileSync for test entries
@@ -99,6 +131,22 @@ assert(!preonlyEntry.latestStableRelease, "latestStableRelease should not be set
 const norelEntry = entries.find(e => e.id === "entry-noreleases");
 assert(norelEntry, "entry-noreleases not found");
 assert(!norelEntry.latestStableRelease, "latestStableRelease should not be set for no-releases entry");
+
+// Test 4: a dated demo tag never becomes the latest *stable* release, even
+// though it is the newest non-prerelease in the list.
+const demoEntry = entries.find(e => e.id === "entry-demotag");
+assert(demoEntry, "entry-demotag not found");
+assert(demoEntry.latestStableRelease, "latestStableRelease should be set for demo-tag entry");
+assert.strictEqual(demoEntry.latestStableRelease.tagName, "v0.2.1",
+  "should skip the newer non-version demo tag and pick the version-shaped release");
+
+// Test 5: when nothing carries a version number, fall back to the newest
+// non-prerelease rather than dropping the callout.
+const noverEntry = entries.find(e => e.id === "entry-noversion");
+assert(noverEntry, "entry-noversion not found");
+assert(noverEntry.latestStableRelease, "latestStableRelease should fall back when no tag has a version");
+assert.strictEqual(noverEntry.latestStableRelease.tagName, "pre_perfmodel_merge",
+  "should fall back to the newest non-prerelease when no version-shaped tag exists");
 
 console.log("✓ latestStableRelease tests passed");
 

--- a/tests/test_fetch_github_meta.py
+++ b/tests/test_fetch_github_meta.py
@@ -117,3 +117,55 @@ def test_fetch_releases_name_falls_back_to_tag():
     with patch("urllib.request.urlopen", return_value=_mock_response(data)):
         result = fetch_releases("foo/bar")
     assert result[0]["name"] == "v2.0.0"
+
+
+# ── release ordering ─────────────────────────────────────────────────────────
+# src/_data/entries.js resolves latestStableRelease with releases.find(...),
+# which takes the FIRST match in array order and therefore assumes the list is
+# newest-first. GitHub's list-releases endpoint sorts by created_at, not
+# published_at, so a release tagged from an older commit but published later
+# (tt-finetune's demo-2026-08-29) arrives out of order and quietly breaks that
+# assumption. Sort here so the invariant the data layer documents is actually
+# guaranteed, for every repo, on every nightly run.
+
+def test_fetch_releases_sorts_newest_published_first():
+    data = [
+        {   # created earlier, published LAST — the out-of-order case
+            "tag_name": "v0.2.1", "name": "v0.2.1",
+            "published_at": "2026-08-28T17:21:58Z",
+            "html_url": "https://github.com/foo/bar/releases/tag/v0.2.1",
+            "prerelease": False, "draft": False,
+        },
+        {
+            "tag_name": "demo-2026-08-29", "name": "Demo",
+            "published_at": "2026-08-29T15:44:38Z",
+            "html_url": "https://github.com/foo/bar/releases/tag/demo-2026-08-29",
+            "prerelease": False, "draft": False,
+        },
+        {
+            "tag_name": "v0.2.0", "name": "v0.2.0",
+            "published_at": "2026-08-26T07:14:15Z",
+            "html_url": "https://github.com/foo/bar/releases/tag/v0.2.0",
+            "prerelease": False, "draft": False,
+        },
+    ]
+    with patch("urllib.request.urlopen", return_value=_mock_response(data)):
+        result = fetch_releases("foo/bar")
+    assert [r["tagName"] for r in result] == ["demo-2026-08-29", "v0.2.1", "v0.2.0"]
+
+
+def test_fetch_releases_sort_tolerates_missing_published_at():
+    # A draft-turned-release can carry a null published_at; it must sort last
+    # rather than raising and costing us the whole repo's release list.
+    data = [
+        {   "tag_name": "v1.0.0", "name": "v1.0.0", "published_at": None,
+            "html_url": "https://github.com/foo/bar/releases/tag/v1.0.0",
+            "prerelease": False, "draft": False },
+        {   "tag_name": "v1.1.0", "name": "v1.1.0",
+            "published_at": "2026-05-01T00:00:00Z",
+            "html_url": "https://github.com/foo/bar/releases/tag/v1.1.0",
+            "prerelease": False, "draft": False },
+    ]
+    with patch("urllib.request.urlopen", return_value=_mock_response(data)):
+        result = fetch_releases("foo/bar")
+    assert [r["tagName"] for r in result] == ["v1.1.0", "v1.0.0"]

--- a/tests/test_summarize_releases.py
+++ b/tests/test_summarize_releases.py
@@ -765,3 +765,149 @@ def test_unreadable_file_does_not_double_warn(tmp_path, capsys):
     p.write_text("{not json")
     assert sr.load_known_release_keys(p) == set()
     assert "WARN" not in capsys.readouterr().err
+
+
+# ── Bodies that are only GitHub's auto-generated "Full Changelog" link ────────
+# These clear SPARSE_LIMIT purely on URL length while carrying no content, so
+# the compare view is crawled for commit subjects instead. See
+# body_defers_to_compare / fetch_compare_log in summarize_releases.py.
+
+BARE_COMPARE_BODY = (
+    "**Full Changelog**: https://github.com/zk4x/zyx/compare/v0.13.0...v0.14.0"
+)
+
+
+def test_body_defers_to_compare_detects_bare_link():
+    url = sr.body_defers_to_compare(BARE_COMPARE_BODY)
+    assert url == "https://github.com/zk4x/zyx/compare/v0.13.0...v0.14.0"
+
+
+def test_body_defers_to_compare_tolerates_formatting_variants():
+    # Angle-bracketed autolink, no bold, and a trailing blank line.
+    body = "Full Changelog: <https://github.com/o/r/compare/v1...v2>\n\n"
+    assert sr.body_defers_to_compare(body) == "https://github.com/o/r/compare/v1...v2"
+
+
+def test_body_defers_to_compare_ignores_body_with_real_notes():
+    # GitHub's generated notes: a real "What's Changed" list *plus* the link.
+    # There is already something to summarize, so we must not crawl.
+    body = (
+        "## What's Changed\n"
+        "* Fix a crash when the device is busy by @someone in #42\n"
+        "* Add BF8 support to the planner by @other in #43\n"
+        "* Speed up tile padding by roughly 30% by @third in #44\n\n"
+        "**Full Changelog**: https://github.com/o/r/compare/v1...v2"
+    )
+    assert sr.body_defers_to_compare(body) is None
+
+
+def test_body_defers_to_compare_returns_none_without_a_link():
+    assert sr.body_defers_to_compare("Bug fixes.") is None
+    assert sr.body_defers_to_compare("") is None
+
+
+def test_parse_compare_url_returns_repo_and_spec():
+    assert sr.parse_compare_url(
+        "https://github.com/zk4x/zyx/compare/v0.13.0...v0.14.0"
+    ) == ("zk4x/zyx", "v0.13.0...v0.14.0")
+
+
+def test_parse_compare_url_rejects_non_compare_urls():
+    assert sr.parse_compare_url("https://github.com/o/r/releases/tag/v1") is None
+    assert sr.parse_compare_url("not a url") is None
+
+
+def _compare_payload(subjects, total=None, merges=0):
+    """Build a /compare API payload with `subjects` as single-parent commits."""
+    commits = [
+        {"commit": {"message": s}, "parents": [{"sha": "a"}]} for s in subjects
+    ]
+    for i in range(merges):
+        commits.append({
+            "commit": {"message": f"Merge pull request #{i} from fork/branch"},
+            "parents": [{"sha": "a"}, {"sha": "b"}],
+        })
+    return {"total_commits": total if total is not None else len(commits),
+            "commits": commits}
+
+
+def test_fetch_compare_log_returns_commit_subjects():
+    payload = _compare_payload([
+        "local memory tiling implemented",
+        "cuda shared memory",
+        "all tensor functions now return proper errors",
+    ])
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+        log = sr.fetch_compare_log("zk4x/zyx", "v0.13.0...v0.14.0")
+    assert log is not None
+    assert "local memory tiling implemented" in log
+    assert "cuda shared memory" in log
+    # The model must be told these are commit subjects, not curated notes.
+    assert "commit" in log.lower()
+
+
+def test_fetch_compare_log_uses_only_first_line_of_each_message():
+    payload = _compare_payload([
+        "Fix the scheduler reshape path\n\nLong body explaining the fix in detail.",
+        "Add softmax to the wgsl backend\n\nAnother paragraph.",
+        "Return proper errors from every tensor function",
+    ])
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+        log = sr.fetch_compare_log("o", "v1...v2")
+    assert "Fix the scheduler reshape path" in log
+    assert "Long body explaining" not in log
+
+
+def test_fetch_compare_log_skips_merge_commits():
+    payload = _compare_payload(
+        ["Add local memory tiling to the wgsl backend",
+         "Implement tensor split and the masked-fill op",
+         "Fix broadcast errors in the reshape scheduler"],
+        merges=3,
+    )
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+        log = sr.fetch_compare_log("o", "v1...v2")
+    assert "Merge pull request" not in log
+
+
+def test_fetch_compare_log_collapses_repeated_subjects():
+    # Real logs repeat: zyx v0.14.0 has "work on multi head attention" twice.
+    payload = _compare_payload([
+        "work on multi head attention",
+        "work on multi head attention",
+        "tensor split implemented",
+        "added local memory tiling",
+    ])
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+        log = sr.fetch_compare_log("o", "v1...v2")
+    assert log.count("work on multi head attention") == 1
+
+
+def test_fetch_compare_log_caps_and_reports_truncation():
+    payload = _compare_payload([f"commit subject number {i}" for i in range(80)])
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+        log = sr.fetch_compare_log("o", "v1...v2", cap=50)
+    assert log.count("\n- ") + log.startswith("- ") <= 50 + 1
+    assert "commit subject number 49" in log
+    assert "commit subject number 50" not in log
+    assert "80" in log  # the true total is still stated
+
+
+def test_fetch_compare_log_returns_none_when_subjects_are_sparse():
+    # One terse commit is not worth a model call — same bar as is_sparse().
+    payload = _compare_payload(["bump"])
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+        assert sr.fetch_compare_log("o", "v1...v2") is None
+
+
+def test_fetch_compare_log_returns_none_on_http_error():
+    import urllib.error
+    with patch("urllib.request.urlopen",
+               side_effect=urllib.error.HTTPError(None, 404, "Not Found", {}, None)):
+        assert sr.fetch_compare_log("o", "v1...v2") is None
+
+
+def test_fetch_compare_log_returns_none_when_all_commits_are_merges():
+    payload = _compare_payload([], merges=4)
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
+        assert sr.fetch_compare_log("o", "v1...v2") is None

--- a/tests/test_summarize_releases.py
+++ b/tests/test_summarize_releases.py
@@ -911,3 +911,53 @@ def test_fetch_compare_log_returns_none_when_all_commits_are_merges():
     payload = _compare_payload([], merges=4)
     with patch("urllib.request.urlopen", return_value=_mock_urlopen(payload)):
         assert sr.fetch_compare_log("o", "v1...v2") is None
+
+
+# Compare links get shared with the view options GitHub puts in the URL bar, so
+# a body can easily carry "?diff=split" or a "#diff-<sha>" anchor. Those belong
+# to the *page*, not to the basehead spec, and interpolating them into the API
+# path yields a 404 and a silently skipped release.
+
+def test_parse_compare_url_strips_query_string():
+    assert sr.parse_compare_url(
+        "https://github.com/zk4x/zyx/compare/v0.13.0...v0.14.0?diff=split"
+    ) == ("zk4x/zyx", "v0.13.0...v0.14.0")
+
+
+def test_parse_compare_url_strips_fragment():
+    assert sr.parse_compare_url(
+        "https://github.com/zk4x/zyx/compare/v0.13.0...v0.14.0#diff-abc123"
+    ) == ("zk4x/zyx", "v0.13.0...v0.14.0")
+
+
+def test_parse_compare_url_strips_query_and_fragment_together():
+    assert sr.parse_compare_url(
+        "https://github.com/o/r/compare/v1...v2?w=1&diff=unified#files_bucket"
+    ) == ("o/r", "v1...v2")
+
+
+def test_parse_compare_url_keeps_slashes_in_branch_names():
+    # Fork and branch comparisons are legitimate basehead specs and must survive
+    # intact — the API takes them as-is.
+    assert sr.parse_compare_url(
+        "https://github.com/o/r/compare/main...fork:feature/new-thing"
+    ) == ("o/r", "main...fork:feature/new-thing")
+
+
+def test_parse_compare_url_rejects_path_traversal():
+    # A release body is attacker-influenced text: any repo owner in the list
+    # writes it. A spec containing a '..' path segment would let the assembled
+    # API URL climb out of /compare/ and hit a different endpoint. The '...'
+    # basehead separator must still be fine.
+    assert sr.parse_compare_url("https://github.com/o/r/compare/../../../users/x") is None
+    assert sr.parse_compare_url("https://github.com/o/r/compare/v1...v2/../../x") is None
+    assert sr.parse_compare_url(
+        "https://github.com/o/r/compare/v1...v2"
+    ) == ("o/r", "v1...v2")
+
+
+def test_body_defers_to_compare_detects_link_with_query_string():
+    body = "**Full Changelog**: https://github.com/o/r/compare/v1...v2?diff=split"
+    url = sr.body_defers_to_compare(body)
+    assert url is not None
+    assert sr.parse_compare_url(url) == ("o/r", "v1...v2")


### PR DESCRIPTION
## What's here

Three related changes, in the order they happened.

### 1. New entry: `tt-finetune`

[danielisraeli2409-jpg/tt-finetune](https://github.com/danielisraeli2409-jpg/tt-finetune) — parameter-efficient fine-tuning (LoRA, rsLoRA, LoRA+, DoRA, IA3) on a single Blackhole P150a, shipped as a self-contained wheel that bundles the TT-XLA/PJRT plugin, TTNN, and the TT-Metal user-space libraries.

Entry decisions worth a reviewer's eye:

- **`affiliation: community`** — personal account, no Tenstorrent org, and no matching employee. Jeremy introduced it in `#devrel-private` as a community project.
- **`language: Python`** despite GitHub reporting C++ by byte count — the C++ is the bundled runtime under `tt_finetune/_resident_bundles`; every source directory is Python.
- **No `packages`** — the README states outright that it does not claim PyPI publication, and the wheel installs from a release URL. No install badge promise we can't keep.

`github_meta.json` was updated by importing `fetch_github_meta`'s functions for this one repo rather than running `main()`, which rewrites all 119 entries and would have buried the change in unrelated star churn.

### 2. Three planet items, rendering as one grouped card

v0.2.0 (8/26), v0.2.1 (8/28), and the `demo-2026-08-29` screen recording chain into a single card: **"3 releases · Aug 26 – Aug 29, 2026"**.

⚠️ **These summaries were written by hand, not by the model.** There is no `ANTHROPIC_API_KEY`/`FOUNDRY_API_KEY` in the local environment, so `summarize_releases.py` could not run. They follow `summarize-release.prompt.yml`'s constraints and use the exact schema `main()` emits, but they did not come out of the usual pipeline — worth reading them as prose rather than assuming they were generated.

### 3. `SPARSE_LIMIT` 120 → 70, plus a compare-link crawl

The demo release is 86 chars, so the old gate would have dropped it permanently.

Lowering the gate was measured, not guessed. Of the releases in `github_meta.json` that the sparse gate is the *only* thing blocking (11, after pre-release and rename filters), the length distribution is:

| chars | release | at 70 |
|---|---|---|
| 101 | `tenstorrent/polaris@pre_perfmodel_merge` | newly in |
| 88 | `zk4x/zyx@v0.11.1` | newly in |
| 86 | `tt-finetune@demo-2026-08-29` | newly in |
| 79 | `tenstorrent/ttsim@v1.10.5` | newly in |
| 73 | `zk4x/zyx@v0.14.0` | newly in |
| 0 ×6 | `tt-system-tools` ×5, `whisper@1.861` | still out |

Nothing lands in 1–69, so 70 sits in a clean gap.

**But 70 opened a hole.** `zk4x/zyx v0.14.0` is 73 chars and its entire body is:

```
**Full Changelog**: https://github.com/zk4x/zyx/compare/v0.13.0...v0.14.0
```

It clears the gate *only because the URL is long*, and there is nothing there to summarize — the model would have to invent one.

So rather than widen or narrow the gate, `body_defers_to_compare` / `parse_compare_url` / `fetch_compare_log` follow the link and summarize the commit subjects behind it. This deliberately mirrors the existing `body_defers_to_changelog` → `fetch_changelog_section` path, and runs *after* it, since curated notes beat a raw commit log when both exist.

On the real release: **73 chars of URL → 835 chars of genuine commit log**, 29 commits deduped to 28.

Design points:

- **Only fires when the link is the whole body.** GitHub's generated "What's Changed" notes end with a Full Changelog line too, and those already have content. The check strips the pointer line and crawls only if what remains is itself sparse. Verified against all five newly-admitted releases: only zyx v0.14.0 crawls.
- **Merge commits dropped, duplicate subjects collapsed** — working branches restate subjects (zyx says "work on multi head attention" twice).
- **The sparse gate applies to the commit subjects alone, before the framing header is added.** The header is ~200 chars, so gating the finished string would carry a single-`bump`-commit release straight through. This is the non-obvious bit; there's a test pinning it.
- **The header tells the model it's reading raw commit messages.** Left implicit, summaries of a commit log drift into describing it as a polished release.
- Best-effort throughout: any API failure returns `None` and the release falls back to being skipped, never published from nothing.

## Testing

```
python3 scripts/validate.py          # 157 entries, no errors
python3 -m pytest tests/ -q          # 210 passed (14 new, written before the implementation)
npm run build
node tests/test_entry_pages.js       # 156 static entry pages verified
node tests/test_data_files.js
node tests/test_eleventy_filters.js
node tests/test_recent_releases.js
```

Detection, crawling, and content assembly were also verified against the live GitHub API for all five newly-admitted releases.

**Not verified:** the model end of the compare crawl. Without an API key locally I could not run an actual summarization, so the first real summary from this path will appear in the next nightly run — worth eyeballing that PR when it lands.
